### PR TITLE
Adding short gene names to the region plot title, and toning down the color scheme

### DIFF
--- a/pheget/frontend/__init__.py
+++ b/pheget/frontend/__init__.py
@@ -127,6 +127,10 @@ def region_view():
     # First, load the gene_id -> gene_symbol conversion table (no version numbers at the end of ENSG's)
     gene_json = model.get_gene_names_conversion()
 
+    # If no symbol is entered but we have gene_id, try to look it up in gene_json
+    if symbol is None:
+        symbol = gene_json.get(gene_id.split(".")[0], None)
+
     # Query the sqlite3 database for the range (chrom:start-end) and get the list of all genes
     conn = sqlite3.connect(model.get_sig_lookup())
     with conn:

--- a/pheget/frontend/templates/frontend/region.html
+++ b/pheget/frontend/templates/frontend/region.html
@@ -14,11 +14,14 @@
         <div id="home-searchbox">
           <form id="variant-search">
             <div class="input-group">
+              <div class="input-group-prepend">
+                  <a href="/" class="btn btn-secondary btn-sm" role="button" aria-pressed="true"><span class="fa fa-home"></span></a>
+              </div>
               <input id="query-field" name="query-field" autocomplete="off" class="form-control"
                      type="text"
                      placeholder="Search for a variant, e.g. chr19:488506 or rs10424907" autofocus/>
               <div class="input-group-append">
-                <button id="navigate-variant" class="btn btn-primary" type="submit">Search <span
+                <button id="navigate-variant" class="btn btn-secondary" type="submit"><span
                     class="fa fa-search"></span></button>
               </div>
             </div>
@@ -26,73 +29,33 @@
         </div>
       </div>
     </div>
-    <center>
-      <a href="/" class="btn btn-primary btn-sm" role="button" aria-pressed="true"><span class="fa fa-home"></span> Back
-        to PheGET Homepage</a>
-    </center>
+    
     <br>
     {#  FIXME: This label does not update as the plot is panned or zoomed. We can resolve this in the future when we move to a dynamic frontend #}
-    <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs near {{ chrom }}:{{ "{:,}".format(center) }} </strong></h1>
+    <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs in {{ chrom }}:{{ "{:,}".format(start) }}-{{ "{:,}".format(end) }} </strong></h1>
+  </div>
+
+  <div class="container-fluid">
+    <div class="row">
+      <div id="lz-plot" class="ten columns">
+      </div>
+    </div>
   </div>
 
   <!-- Bootstrap dropdown menu to choose an additional tissue to plot -->
   <div class="container-fluid">
     <div class="row justify-content-start pb-1">
       <div class="col-sm">
+
         <div class="btn-group pr-1">
           <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                title="Add a new tissue with the current anchor gene, or add a new gene with the current anchor tissue">
-            <button type="button" class="btn btn-secondary" style="pointer-events: none;"> <span class="fa fa-plus"></span></button>
-          </span>
-          <div class="dropdown">
-            <button class="btn btn-info dropdown-toggle" type="button" id="dropdown_tissueselect" data-toggle="dropdown" data-toggle-second="tooltip"
-                    aria-haspopup="true" aria-expanded="false" title="Add a new panel with the selected tissue and the current anchor gene">
-              Tissue
-            </button>
-            <!-- Dynamically generate tissue buttons from tissue_list -->
-            <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_tissueselect">
-              {% for single_tissue in tissue_list %}
-              <button class="dropdown-item tissueselect-class" type="button" value="{{ single_tissue }}">{{ single_tissue }}</button>
-              {% endfor %}
-            </div>
-          </div>
-          <div class="dropdown">
-            <button class="btn btn-info dropdown-toggle" type="button" id="dropdown_geneselect" data-toggle="dropdown" data-toggle-second="tooltip"
-                    aria-haspopup="true" aria-expanded="false" title="Add a new panel with the selected gene and the current anchor tissue">
-              Gene
-            </button>
-            <!-- Dynamically generate gene list -->
-            <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_geneselect">
-              {% for single_geneid, single_symbol in gene_list.items() %}
-              <button class="dropdown-item geneselect-class" type="button" data-genesymbol="{{ single_symbol }}" data-geneid="{{ single_geneid }}"><i>{{ single_symbol }}</i></button>
-              {% endfor %}
-            </div>
-          </div>
-        </div>
-
-        <div class="btn-group">
-          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
                 title="Choose a new anchor tissue or gene">
-            <button type="button" class="btn btn-secondary" style="pointer-events: none;"> <span class="fa fa-anchor"></span></button>
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-anchor"></span></button>
           </span>
-
           <div class="dropdown">
-            <button class="btn btn-primary dropdown-toggle" type="button" id="dropdown_anchortissueselect" data-toggle="dropdown" data-toggle-second="tooltip"
-                    aria-haspopup="true" aria-expanded="false" title="Choose a tissue to serve as an anchor">
-                    <span class="anchortissue"></span>
-            </button>
-            <!-- Dynamically generate list of anchor tissue buttons -->
-            <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_anchortissueselect">
-                {% for single_tissue in tissue_list %}
-                <button class="dropdown-item anchortissueselect-class" type="button" value="{{ single_tissue }}">{{ single_tissue }}</button>
-                {% endfor %}
-            </div>
-          </div>
-
-          <div class="dropdown">
-            <button class="btn btn-primary dropdown-toggle" type="button" id="dropdown_anchorgeneselect" data-toggle="dropdown" data-toggle-second="tooltip"
-                    aria-haspopup="true" aria-expanded="false" title="Choose a gene to serve as an anchor">
-                    <i><span class="anchorgene"></span></i>
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdown_anchorgeneselect" data-toggle="dropdown" data-toggle-second="tooltip"
+                  aria-haspopup="true" aria-expanded="false" title="Choose a gene to serve as an anchor">
+              <i><span class="anchorgene"></span></i>
             </button>
             <!-- Dynamically generate anchor gene list -->
             <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_anchorgeneselect">
@@ -101,38 +64,86 @@
               {% endfor %}
             </div>
           </div>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <div class="container-fluid">
-    <div class="row justify-content-start pb-1">
-      <div class="col-sm">
-        <form class="yaxis-display" id="transform-y">
-          <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                title="Switches the y variable between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
-            <button type="button" class="btn btn-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
+          <span class="d-inline-block">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> in</button>
           </span>
-            <label class="btn btn-success active" data-toggle="tooltip" data-placement="top" data-html="true"
-                   title="Display -log<sub>10</sub>(P-values) on the Y-axis">
-              <input type="radio" name="y-options" autocomplete=off id="show-log-pvalue" value="log_pvalue"> P-values
-            </label>
-            <label class="btn btn-success" data-toggle="tooltip" data-placement="top" data-html="true"
-                   title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
-              <input type="radio" name="y-options" autocomplete=off id="show-beta" value="beta"> Effect Size (NES)
-            </label>
+
+          <div class="dropdown">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdown_anchortissueselect" data-toggle="dropdown" data-toggle-second="tooltip"
+                aria-haspopup="true" aria-expanded="false" title="Choose a tissue to serve as an anchor">
+                <span class="anchortissue"></span>
+            </button>
+            <!-- Dynamically generate list of anchor tissue buttons -->
+            <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_anchortissueselect">
+                {% for single_tissue in tissue_list %}
+                  <button class="dropdown-item anchortissueselect-class" type="button" value="{{ single_tissue }}">{{ single_tissue }}</button>
+                {% endfor %}
+            </div>
           </div>
-        </form>
-      </div>
-    </div>
-  </div>
+        </div>
 
+        <div class="btn-group pr-1">
+          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
+                title="Add a new gene with the current anchor tissue">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-plus"></span></button>
+          </span>
+          <div class="dropdown">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdown_geneselect" data-toggle="dropdown" data-toggle-second="tooltip"
+                    aria-haspopup="true" aria-expanded="false" title="Choose a gene to add a new panel showing eQTLs between that gene and the current anchor tissue">
+              Gene
+            </button>
+            <!-- Dynamically generate gene list -->
+            <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_geneselect">
+              {% for single_geneid, single_symbol in gene_list.items() %}
+               <button class="dropdown-item geneselect-class" type="button" data-genesymbol="{{ single_symbol }}" data-geneid="{{ single_geneid }}"><i>{{ single_symbol }}</i></button>
+              {% endfor %}
+            </div>
+          </div>
+          <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;">in</button>
+          <button type="button" class="btn btn-outline-secondary anchor-tissue-label" style="pointer-events: none;">{{ tissue }}</button>
+        </div>
 
-  <div class="container-fluid">
-    <div class="row">
-      <div id="lz-plot" class="ten columns">
+        <div class="btn-group pr-1">
+          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
+            title="Add a new tissue with the current anchor gene">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-plus"></span></button>
+          </span>
+          <button type="button" class="btn btn-outline-secondary anchor-gene-label" style="pointer-events: none;"><i>{{ symbol }}</i></button>
+          <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;">in</button>
+          <div class="dropdown">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdown_tissueselect" data-toggle="dropdown" data-toggle-second="tooltip"
+                  aria-haspopup="true" aria-expanded="false" title="Choose a tissue to add a new panel with eQTLs between that tissue and the current anchor gene">
+            Tissue
+            </button>
+          <!-- Dynamically generate tissue buttons from tissue_list -->
+            <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_tissueselect">
+              {% for single_tissue in tissue_list %}
+              <button class="dropdown-item tissueselect-class" type="button" value="{{ single_tissue }}">{{ single_tissue }}</button>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+
+        <div class="btn-group pr-1">
+          <form class="yaxis-display" id="transform-y">
+            <div class="btn-group btn-group-toggle" data-toggle="buttons">
+              <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
+                  title="Switches the y variable between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
+                <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
+              </span>
+              <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top" data-html="true"
+                  title="Display -log<sub>10</sub>(P-values) on the Y-axis">
+                <input type="radio" name="y-options" autocomplete=off id="show-log-pvalue" value="log_pvalue"> P-values
+              </label>
+              <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top" data-html="true"
+                  title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
+                <input type="radio" name="y-options" autocomplete=off id="show-beta" value="beta"> Effect Size (NES)
+              </label>
+            </div>
+          </form>
+        </div>
+
       </div>
     </div>
   </div>
@@ -193,6 +204,7 @@
           selectedAnchorTissue.addEventListener('click', (event) => {
             ANCHOR_TISSUE = event.currentTarget.value;
             document.querySelector('.anchortissue').innerHTML = ANCHOR_TISSUE;
+            document.querySelector('.anchor-tissue-label').innerHTML = ANCHOR_TISSUE;
             let panel_ids = Array.from(plot.layout.panels, panel => panel.id);
             panel_ids.forEach(function(id){
               if (id !=='genes'){
@@ -210,6 +222,7 @@
             ANCHOR_GENE = event.currentTarget.dataset.geneid;
             ANCHOR_SYMBOL = event.currentTarget.dataset.genesymbol;
             document.querySelector('.anchorgene').innerHTML = GENE_DICT[ANCHOR_GENE];
+            document.querySelector('.anchor-gene-label').innerHTML = GENE_DICT[ANCHOR_GENE]
             let panel_ids = Array.from(plot.layout.panels, panel => panel.id);
             panel_ids.forEach(function(id){
               if (id !=='genes'){

--- a/pheget/frontend/templates/frontend/region.html
+++ b/pheget/frontend/templates/frontend/region.html
@@ -29,7 +29,7 @@
         </div>
       </div>
     </div>
-    
+
     <br>
     {#  FIXME: This label does not update as the plot is panned or zoomed. We can resolve this in the future when we move to a dynamic frontend #}
     <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs in {{ chrom }}:{{ "{:,}".format(start) }}-{{ "{:,}".format(end) }} </strong></h1>
@@ -37,7 +37,7 @@
 
   <div class="container-fluid">
     <div class="row">
-      <div id="lz-plot" class="ten columns">
+      <div id="lz-plot">
       </div>
     </div>
   </div>
@@ -82,7 +82,7 @@
             </div>
           </div>
         </div>
-      </div>        
+      </div>
       <div class="col-sm">
         Add plot for a new gene in the anchor tissue<br>
         <div class="btn-group pr-1">
@@ -162,7 +162,7 @@
       <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top" data-html="true"
         title="Created by Alan Kwong, Mukai Wang, Andy Boughton, Peter VandeHaar, and Hyun Min Kang. Source code can be found on <a href=https://github.com/statgen/pheget/>GitHub</a>.">
         <span class="badge badge-pill badge-secondary" style="pointer-events: none;">
-          <span class="fa fa-lightbulb-o"></span> Credits 
+          <span class="fa fa-lightbulb-o"></span> Credits
         </span>
       </span>
     </div>

--- a/pheget/frontend/templates/frontend/region.html
+++ b/pheget/frontend/templates/frontend/region.html
@@ -44,13 +44,13 @@
 
   <!-- Bootstrap dropdown menu to choose an additional tissue to plot -->
   <div class="container-fluid">
-    <div class="row justify-content-start pb-1">
+    <div class="row justify-content-start">
       <div class="col-sm">
-
+        Set a default gene or tissue as the anchor<br>
         <div class="btn-group pr-1">
           <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                title="Choose a new anchor tissue or gene">
-            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-anchor"></span></button>
+                title="Choose a new <b>anchor tissue</b> or <b>gene</b>. All other added plots will be based on these anchors: when you add a <b>new gene</b>, the eQTLs plotted will be between that gene and the <b>anchor tissue</b>; when you add a <b>new tissue</b>, the eQTLs plotted will be between that tissue and the <b>anchor gene</b>. <br>Changing either anchor will delete all other plots and generate a single new plot, with eQTLs for the anchor gene in the anchor tissue.">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"><span class="fa fa-info-circle"></span> <span class="fa fa-anchor"></span></button>
           </span>
           <div class="dropdown">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdown_anchorgeneselect" data-toggle="dropdown" data-toggle-second="tooltip"
@@ -82,10 +82,12 @@
             </div>
           </div>
         </div>
-
+      </div>        
+      <div class="col-sm">
+        Add plot for a new gene in the anchor tissue<br>
         <div class="btn-group pr-1">
           <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                title="Add a new gene with the current anchor tissue">
+                title="Add an eQTL plot for a gene in the current anchor tissue">
             <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-plus"></span></button>
           </span>
           <div class="dropdown">
@@ -103,7 +105,9 @@
           <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;">in</button>
           <button type="button" class="btn btn-outline-secondary anchor-tissue-label" style="pointer-events: none;">{{ tissue }}</button>
         </div>
-
+      </div>
+      <div class="col-sm">
+        Add plot for the anchor gene in a new tissue
         <div class="btn-group pr-1">
           <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
             title="Add a new tissue with the current anchor gene">
@@ -124,13 +128,15 @@
             </div>
           </div>
         </div>
-
+      </div>
+      <div class="col-sm">
+        Change the plotted values
         <div class="btn-group pr-1">
           <form class="yaxis-display" id="transform-y">
             <div class="btn-group btn-group-toggle" data-toggle="buttons">
               <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
                   title="Switches the y variable between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
-                <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
+                <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Y-Axis: </button>
               </span>
               <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top" data-html="true"
                   title="Display -log<sub>10</sub>(P-values) on the Y-axis">
@@ -138,15 +144,30 @@
               </label>
               <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top" data-html="true"
                   title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
-                <input type="radio" name="y-options" autocomplete=off id="show-beta" value="beta"> Effect Size (NES)
+                <input type="radio" name="y-options" autocomplete=off id="show-beta" value="beta"> Effect Size
               </label>
             </div>
           </form>
         </div>
-
       </div>
+
     </div>
   </div>
+
+<br>
+
+<div class="container-fluid">
+  <div class="card">
+    <div class="card-body">
+      <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top" data-html="true"
+        title="Created by Alan Kwong, Mukai Wang, Andy Boughton, Peter VandeHaar, and Hyun Min Kang. Source code can be found on <a href=https://github.com/statgen/pheget/>GitHub</a>.">
+        <span class="badge badge-pill badge-secondary" style="pointer-events: none;">
+          <span class="fa fa-lightbulb-o"></span> Credits 
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
 
 {% endblock %}
 
@@ -212,6 +233,7 @@
               }
             });
             // FIXME: seems to be an ugly way of removing panels one by one
+            // TODO: When changing anchors, simply redirect to new URL with the new anchors
             addTrack(window.plot, window.datasources, ANCHOR_GENE, ANCHOR_TISSUE, ANCHOR_SYMBOL);
           });
       });
@@ -230,7 +252,7 @@
               }
             });
             // FIXME: seems to be an ugly way of removing panels one by one
-            // TODO: Delete all other tracks
+            // TODO: Same as above - redirect to new URL with new anchors
             addTrack(window.plot, window.datasources, ANCHOR_GENE, ANCHOR_TISSUE, ANCHOR_SYMBOL);
           });
       });

--- a/pheget/frontend/templates/frontend/region.html
+++ b/pheget/frontend/templates/frontend/region.html
@@ -32,7 +32,7 @@
     </center>
     <br>
     {#  FIXME: This label does not update as the plot is panned or zoomed. We can resolve this in the future when we move to a dynamic frontend #}
-    <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs near {{ chrom }}:{{ center }} </strong></h1>
+    <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs near {{ chrom }}:{{ center }}</strong></h1>
   </div>
 
   <!-- Bootstrap dropdown menu to choose an additional tissue to plot -->
@@ -64,7 +64,7 @@
             <!-- Dynamically generate gene list -->
             <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_geneselect">
               {% for single_geneid, single_symbol in gene_list.items() %}
-              <button class="dropdown-item geneselect-class" type="button" value="{{ single_geneid }}"><i>{{ single_symbol }}</i></button>
+              <button class="dropdown-item geneselect-class" type="button" data-genesymbol="{{ single_symbol }}" data-geneid="{{ single_geneid }}"><i>{{ single_symbol }}</i></button>
               {% endfor %}
             </div>
           </div>
@@ -97,7 +97,7 @@
             <!-- Dynamically generate anchor gene list -->
             <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdown_anchorgeneselect">
               {% for single_geneid, single_symbol in gene_list.items() %}
-                <button class="dropdown-item anchorgeneselect-class" type="button" value="{{ single_geneid }}"><i>{{ single_symbol }}</i></button>
+                <button class="dropdown-item anchorgeneselect-class" type="button" data-genesymbol="{{ single_symbol }}" data-geneid="{{ single_geneid }}"><i>{{ single_symbol }}</i></button>
               {% endfor %}
             </div>
           </div>
@@ -156,10 +156,11 @@
   <script type="application/javascript">
       'use strict';
       var ANCHOR_GENE = {{gene_id|tojson}};
+      var ANCHOR_SYMBOL = {{symbol|tojson}};
       var ANCHOR_TISSUE = {{tissue|tojson}};
       var GENE_DICT = {{gene_list|tojson}};
 
-      [window.plot, window.datasources] = makeSinglePlot(ANCHOR_GENE, ANCHOR_TISSUE, '#lz-plot');
+      [window.plot, window.datasources] = makeSinglePlot(ANCHOR_GENE, ANCHOR_TISSUE, '#lz-plot', ANCHOR_SYMBOL);
 
       // Use omnisearch (https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch) to parse
       document.getElementById('variant-search').addEventListener('submit', function (event) {
@@ -176,14 +177,14 @@
       var tissueElements = document.getElementsByClassName('tissueselect-class');
       Array.from(tissueElements).forEach((selectedTissue) => {
           selectedTissue.addEventListener('click', (event) => {
-              addTrack(window.plot, window.datasources, ANCHOR_GENE, event.currentTarget.value);
+              addTrack(window.plot, window.datasources, ANCHOR_GENE, event.currentTarget.value, ANCHOR_SYMBOL);
           });
       });
 
       var geneElements = document.getElementsByClassName('geneselect-class');
       Array.from(geneElements).forEach((selectedGene) => {
           selectedGene.addEventListener('click', (event) => {
-              addTrack(window.plot, window.datasources, event.currentTarget.value, ANCHOR_TISSUE);
+              addTrack(window.plot, window.datasources, event.currentTarget.dataset.geneid, ANCHOR_TISSUE, event.currentTarget.dataset.genesymbol);
           });
       });
 
@@ -199,14 +200,15 @@
               }
             });
             // FIXME: seems to be an ugly way of removing panels one by one
-            addTrack(window.plot, window.datasources, ANCHOR_GENE, ANCHOR_TISSUE);
+            addTrack(window.plot, window.datasources, ANCHOR_GENE, ANCHOR_TISSUE, ANCHOR_SYMBOL);
           });
       });
 
       var anchorgeneElements = document.getElementsByClassName('anchorgeneselect-class');
       Array.from(anchorgeneElements).forEach((selectedAnchorGene) => {
           selectedAnchorGene.addEventListener('click', (event) => {
-            ANCHOR_GENE = event.currentTarget.value;
+            ANCHOR_GENE = event.currentTarget.dataset.geneid;
+            ANCHOR_SYMBOL = event.currentTarget.dataset.genesymbol;
             document.querySelector('.anchorgene').innerHTML = GENE_DICT[ANCHOR_GENE];
             let panel_ids = Array.from(plot.layout.panels, panel => panel.id);
             panel_ids.forEach(function(id){
@@ -216,7 +218,7 @@
             });
             // FIXME: seems to be an ugly way of removing panels one by one
             // TODO: Delete all other tracks
-            addTrack(window.plot, window.datasources, ANCHOR_GENE, ANCHOR_TISSUE);
+            addTrack(window.plot, window.datasources, ANCHOR_GENE, ANCHOR_TISSUE, ANCHOR_SYMBOL);
           });
       });
 

--- a/pheget/frontend/templates/frontend/variant.html
+++ b/pheget/frontend/templates/frontend/variant.html
@@ -19,16 +19,20 @@
 
 {% block content %}
   <div class="container-fluid">
+
     <div class="row padtop">
       <div class="col-sm-10">
         <div id="home-searchbox">
           <form id="variant-search">
             <div class="input-group">
+              <div class="input-group-prepend">
+                  <a href="/" class="btn btn-secondary btn-sm" role="button" aria-pressed="true"><span class="fa fa-home"></span></a>
+              </div>
               <input id="query-field" name="query-field" autocomplete="off" class="form-control"
-                     type="text"
-                     placeholder="Search for a variant, e.g. chr19:488506 or rs10424907" autofocus/>
+                      type="text"
+                      placeholder="Search for a variant, e.g. chr19:488506 or rs10424907" autofocus/>
               <div class="input-group-append">
-                <button id="navigate-variant" class="btn btn-primary" type="submit">Search <span
+                <button id="navigate-variant" class="btn btn-secondary" type="submit"><span
                     class="fa fa-search"></span></button>
               </div>
             </div>
@@ -36,24 +40,147 @@
         </div>
       </div>
     </div>
-    <center>
-      <a href="/" class="btn btn-primary btn-sm" role="button" aria-pressed="true"><span class="fa fa-home"></span> Back
-        to PheGET Homepage</a>
-    </center>
-    <br>
+  </div>
 
-    <h1>Variant: chr{{ chrom }}:{{ "{:,}".format(pos) }} {{ ref }}/{{ alt }} ({{ rsid }})</h1>
+  <div class="container-fluid">
+    <div class="row padtop">
+      <div class="col">
+        <h1>Variant: chr{{ chrom }}:{{ "{:,}".format(pos) }} {{ ref }}/{{ alt }} ({{ rsid }})</h1>
+      </div>
+    </div>
+  </div>
 
+  <div class="container-fluid">
+    <div class="row justify-content-start">
+      <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
+        <form class="grouping" id="grouping-buttons">
+          <div class="btn-group btn-group-toggle" data-toggle="buttons">
+          <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                title="Reorder the x-axis by one of these listed categories" data-placement="top">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-exchange-alt"></span> Group by: </button>
+          </span>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Group eQTLs by tissues, sorted alphabetically">
+              <input type="radio" name="group-options" autocomplete=off value="tissue"> Tissue
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Group eQTLs by systems as defined by the GTEx project, sorted alphabetically">
+              <input type="radio" name="group-options" autocomplete=off value="system"> System
+            </label>
+            <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top"
+                   title="Group eQTLs by gene, sorted by the position of the genes' transcription start sites">
+              <input type="radio" name="group-options" autocomplete=off value="symbol"> Gene
+            </label>
+          </div>
+        </form>
+      </div>
+
+      <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
+        <form class="yaxis-display" id="transform-y">
+          <div class="btn-group btn-group-toggle" data-toggle="buttons">
+          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
+                title="Switches the variable plotted on the Y-axis between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
+          </span>
+            <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top" data-html="true"
+                   title="Display -log<sub>10</sub>(P-values) on the Y-axis">
+              <input type="radio" name="y-options" autocomplete=off value="log_pvalue"> P-values
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top" data-html="true"
+                   title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
+              <input type="radio" name="y-options" autocomplete=off value="beta"> Effect Size (NES)
+            </label>
+          </div>
+        </form>
+      </div>
+
+      <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
+        <form class="label-display" id="toggle-labels">
+          <div class="btn-group btn-group-toggle" data-toggle="buttons">
+          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top" data-html="true"
+                title="Toggles labels for the most significant eQTLs. Significance is determined by P-values. <b>Will only label variants more significant than 10<sup>-20</sup></b>. When viewing <b>Effect Size (NES)</b>, show either 5 or 50 eQTLs with the largest absolute effects <b>only</b> if they are also more significant than 10<sup>-20</sup></b>.">
+            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-tag"></span> Label: </button>
+          </span>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Turn off all labels">
+              <input type="radio" name="label-options" autocomplete=off value="0"> None
+            </label>
+            <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top" data-html="true"
+                   title="If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-20</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
+              <input type="radio" name="label-options" autocomplete=off value="5"> Top 5
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top" data-html="true"
+                   title="If viewing P-values, add labels to the 50 eQTLs with the most significant P-values <b>if they are most significant than 10<sup>-20</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 50 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
+              <input type="radio" name="label-options" autocomplete=off value="50"> Top 50
+            </label>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Filters all points by TSS. Applies a region filter which is symmetric around the current point -->
+    <div class="row justify-content-start">
+      <div class="col-12" style="margin-bottom:0.8em">
+        <form class="tss-range" id="tss-both-range">
+          <div class="btn-group btn-group-toggle" data-toggle="buttons">
+            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
+                  title="Display eQTLs for genes <b>only</b> if their Transcription Start Sites (TSS's) are within the selected distance from this variant.">
+              <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;">
+                <span class="fa fa-arrows-alt-h"></span> Filter by TSS Distance
+              </button>
+            </span>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 20000, 1] | max) }}-{{ '{:,}'.format(pos + 20000) }}">
+              <input type="radio" name="tss-options" autocomplete=off value="20000"> ±20kb
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 50000, 1] | max) }}-{{ '{:,}'.format(pos + 50000) }}">
+              <input type="radio" name="tss-options" autocomplete=off value="50000"> ±50kb
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 100000, 1] | max) }}-{{ '{:,}'.format(pos + 100000) }}">
+              <input type="radio" name="tss-options" autocomplete=off value="100000"> ±100kb
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 200000, 1] | max) }}-{{ '{:,}'.format(pos + 200000) }}">
+              <input type="radio" name="tss-options" autocomplete=off value="200000"> ±200kb
+            </label>
+            <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
+                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 500000, 1] | max) }}-{{ '{:,}'.format(pos + 500000) }}">
+              <input type="radio" name="tss-options" autocomplete=off value="500000"> ±500kb
+            </label>
+            <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top"
+                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 1000000, 1] | max) }}-{{ '{:,}'.format(pos + 1000000) }}">
+              <input type="radio" name="tss-options" autocomplete=off value="1000000"> ±1mb
+            </label>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="container-fluid">
+    <div id="lz-plot"></div>
+  </div>
+  
+  <div class="container-fluid">
+    <div class="row justify-content-center">
+      <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
+        title="The red dotted line indicates the current variant's position with respect to the scale on the gene track.">
+        <span class="badge badge-pill badge-secondary" style="pointer-events: none;"><span class="fa fa-question"></span> Red dotted line </span>
+      </span>
+    </div>
+  </div>
+
+
+  <div class="container-fluid">
     <div class="row">
       <div class="col">
-        <button class="btn btn-info" type="button" data-toggle="collapse" data-target="#variantInformation"
+        <button class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#variantInformation"
                 aria-expanded="true" aria-controls="variantInformation">
           Variant Information from Sequence Genotype <span class="fa fa-caret-down"></span>
         </button>
         <div class="collapse show" id="variantInformation">
-
           <div class="card-group">
-
             <div class="card variant-information-grouped-card">
               <div class="card-body">
                 <dl class="variant-information-dl">
@@ -119,181 +246,59 @@
 
           <div class="card">
             <div class="card-body">
-                <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
-                      title="External links for more information about this variant">
-                  <button class="btn btn-sm btn-secondary" style="pointer-events: none;"><span
-                      class="fa fa-info-circle"></span> Variant info </button>
-                </span>
+              <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
+                    title="External links for more information about this variant">
+                <button class="btn btn-sm btn-secondary" style="pointer-events: none;"><span
+                    class="fa fa-secondary-circle"></span> Variant info </button>
+              </span>
               {% if ref is not none and alt is not none %}
                 <a href="https://bravo.sph.umich.edu/freeze5/hg38/variant/{{ chrom }}-{{ pos }}-{{ ref }}-{{ alt }}"
-                   class="btn btn-primary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
-                   data-placement="top" data-html=true
-                   title="Variant data from NHLBI's TOPMed program, containing 463 million variants observed in 62,784 individuals in data freeze 5. <b>Requires Google login</b>">
+                    class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+                    data-placement="top" data-html=true
+                    title="Variant data from NHLBI's TOPMed program, containing 463 million variants observed in 62,784 individuals in data freeze 5. <b>Requires Google login</b>">
                   BRAVO <span class="fa fa-external-link-alt"></span> </a>
                 <a href="https://gtexportal.org/home/snp/chr{{ chrom }}_{{ pos }}_{{ ref }}_{{ alt }}_b38"
-                   class="btn btn-primary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
-                   data-placement="top"
-                   title="Variant data from the Genotype-Tissue Expression project, containing expression data, histology images, and in-depth expression data analysis">
+                    class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+                    data-placement="top"
+                    title="Variant data from the Genotype-Tissue Expression project, containing expression data, histology images, and in-depth expression data analysis">
                   GTEx Portal <span class="fa fa-external-link-alt"></span> </a>
                 <a href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr{{ chrom }}%3A{{ pos }}-{{ pos }}&position=chr{{ chrom }}%3A{{ pos - 25 }}-{{ pos + 25 }}"
-                   class="btn btn-primary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
-                   data-placement="top" title="The UC Santa Cruz Genome Browser"> UCSC <span
+                    class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+                    data-placement="top" title="The UC Santa Cruz Genome Browser"> UCSC <span
                     class="fa fa-external-link-alt"></span></a>
                 <a href="https://gnomad.broadinstitute.org/variant/{{ chrom }}-{{ pos }}-{{ ref }}-{{ alt }}?dataset=gnomad_r3"
-                   class="btn btn-primary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
-                   data-placement="top"
-                   title="The Genome Aggregation Database (v3) at the Broad Institute, containing variant data from 71,702 sequenced genomes">
+                    class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+                    data-placement="top"
+                    title="The Genome Aggregation Database (v3) at the Broad Institute, containing variant data from 71,702 sequenced genomes">
                   gnomAD <span class="fa fa-external-link-alt"></span></a>
               {% endif %}
               {% if rsid is not none %}
-                <a href="https://www.ncbi.nlm.nih.gov/snp/{{ rsid }}" class="btn btn-primary btn-sm" role="button"
-                   aria-pressed="true" data-toggle="tooltip" data-placement="top"
-                   title="Reference SNP Report from the National Center for Biotechnology Information (NCBI)"> dbSNP
+                <a href="https://www.ncbi.nlm.nih.gov/snp/{{ rsid }}" class="btn btn-secondary btn-sm" role="button"
+                    aria-pressed="true" data-toggle="tooltip" data-placement="top"
+                    title="Reference SNP Report from the National Center for Biotechnology Information (NCBI)"> dbSNP
                   <span class="fa fa-external-link-alt"></span> </a>
-                <a href="http://pheweb.sph.umich.edu/go?query={{ rsid }}" class="btn btn-primary btn-sm" role="button"
-                   aria-pressed="true" data-toggle="tooltip" data-placement="top"
-                   title="PheWeb summary of association results from 1,448 electronic health record-derived phenotypes tested against up to ~6,000 cases and ~18,000 controls with genotyped and imputed samples from the Michigan Genomics Initiative">
+                <a href="http://pheweb.sph.umich.edu/go?query={{ rsid }}" class="btn btn-secondary btn-sm" role="button"
+                    aria-pressed="true" data-toggle="tooltip" data-placement="top"
+                    title="PheWeb summary of association results from 1,448 electronic health record-derived phenotypes tested against up to ~6,000 cases and ~18,000 controls with genotyped and imputed samples from the Michigan Genomics Initiative">
                   MGI <span class="fa fa-external-link-alt"></span></a>
-                <a href="http://pheweb.sph.umich.edu/SAIGE-UKB/go?query={{ rsid }}" class="btn btn-primary btn-sm"
-                   role="button" aria-pressed="true" data-toggle="tooltip" data-placement="top"
-                   title="PheWeb summary of association results from the UK Biobank, with up to ~78k cases and ~409k controls, with binary outcomes analyzed with the SAIGE software">
+                <a href="http://pheweb.sph.umich.edu/SAIGE-UKB/go?query={{ rsid }}" class="btn btn-secondary btn-sm"
+                    role="button" aria-pressed="true" data-toggle="tooltip" data-placement="top"
+                    title="PheWeb summary of association results from the UK Biobank, with up to ~78k cases and ~409k controls, with binary outcomes analyzed with the SAIGE software">
                   UKB-SAIGE <span class="fa fa-external-link-alt"></span></a>
-                <a href="http://big.stats.ox.ac.uk/go?query={{ rsid }}" class="btn btn-primary btn-sm" role="button"
-                   aria-pressed="true" data-toggle="tooltip" data-placement="top"
-                   title="Summary of 3,144 GWAS of Brain Imaging Derived Phenotypes (IDPs) in 9,707 participants from the UK Biobank, analyzed with the BGENIE software">
+                <a href="http://big.stats.ox.ac.uk/go?query={{ rsid }}" class="btn btn-secondary btn-sm" role="button"
+                    aria-pressed="true" data-toggle="tooltip" data-placement="top"
+                    title="Summary of 3,144 GWAS of Brain Imaging Derived Phenotypes (IDPs) in 9,707 participants from the UK Biobank, analyzed with the BGENIE software">
                   UKB-Oxford BIG <span class="fa fa-external-link-alt"></span></a>
               {% endif %}
             </div>
           </div>
-
         </div>
       </div>
     </div>
-
-    <br>
-
-    <div class="row justify-content-start">
-
-      <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
-        <form class="grouping" id="grouping-buttons">
-          <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
-                title="Reorder the x-axis by one of these listed categories" data-placement="top">
-            <button type="button" class="btn btn-secondary" style="pointer-events: none;"> <span class="fa fa-exchange-alt"></span> Group by: </button>
-          </span>
-            <label class="btn btn-primary" data-toggle="tooltip" data-placement="top"
-                   title="Group eQTLs by tissues, sorted alphabetically">
-              <input type="radio" name="group-options" autocomplete=off value="tissue"> Tissue
-            </label>
-            <label class="btn btn-primary" data-toggle="tooltip" data-placement="top"
-                   title="Group eQTLs by systems as defined by the GTEx project, sorted alphabetically">
-              <input type="radio" name="group-options" autocomplete=off value="system"> System
-            </label>
-            <label class="btn btn-primary active" data-toggle="tooltip" data-placement="top"
-                   title="Group eQTLs by gene, sorted by the position of the genes' transcription start sites">
-              <input type="radio" name="group-options" autocomplete=off value="symbol"> Gene
-            </label>
-          </div>
-        </form>
-      </div>
-
-      <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
-        <form class="yaxis-display" id="transform-y">
-          <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                title="Switches the variable plotted on the Y-axis between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
-            <button type="button" class="btn btn-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
-          </span>
-            <label class="btn btn-success active" data-toggle="tooltip" data-placement="top" data-html="true"
-                   title="Display -log<sub>10</sub>(P-values) on the Y-axis">
-              <input type="radio" name="y-options" autocomplete=off value="log_pvalue"> P-values
-            </label>
-            <label class="btn btn-success" data-toggle="tooltip" data-placement="top" data-html="true"
-                   title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
-              <input type="radio" name="y-options" autocomplete=off value="beta"> Effect Size (NES)
-            </label>
-          </div>
-        </form>
-      </div>
-
-      <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
-        <form class="label-display" id="toggle-labels">
-          <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <span class="d-inline=block" tabindex="0" data-toggle="tooltip" data-placement="top" data-html="true"
-                title="Toggles labels for the most significant eQTLs. Significance is determined by P-values. <b>Will only label variants more significant than 10<sup>-20</sup></b>. When viewing <b>Effect Size (NES)</b>, show either 5 or 50 eQTLs with the largest absolute effects <b>only</b> if they are also more significant than 10<sup>-20</sup></b>.">
-            <button type="button" class="btn btn-secondary" style="pointer-events: none;"> <span class="fa fa-tag"></span> Label: </button>
-          </span>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top" title="Turn off all labels">
-              <input type="radio" name="label-options" autocomplete=off value="0"> None
-            </label>
-            <label class="btn btn-info active" data-toggle="tooltip" data-placement="top" data-html="true"
-                   title="If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-20</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
-              <input type="radio" name="label-options" autocomplete=off value="5"> Top 5
-            </label>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top" data-html="true"
-                   title="If viewing P-values, add labels to the 50 eQTLs with the most significant P-values <b>if they are most significant than 10<sup>-20</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 50 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
-              <input type="radio" name="label-options" autocomplete=off value="50"> Top 50
-            </label>
-          </div>
-        </form>
-      </div>
-
-    </div>
-
-    <!-- Filters all points by TSS. Applies a region filter which is symmetric around the current point -->
-    <div class="row justify-content-start">
-      <div class="col-12" style="margin-bottom:0.8em">
-        <form class="tss-range" id="tss-both-range">
-          <div class="btn-group btn-group-toggle" data-toggle="buttons">
-            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                  title="Display eQTLs for genes <b>only</b> if their Transcription Start Sites (TSS's) are within the selected distance from this variant.">
-              <button type="button" class="btn btn-secondary" style="pointer-events: none;">
-                <span class="fa fa-arrows-alt-h"></span> Filter by TSS Distance
-              </button>
-            </span>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top"
-                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 20000, 1] | max) }}-{{ '{:,}'.format(pos + 20000) }}">
-              <input type="radio" name="tss-options" autocomplete=off value="20000"> ±20kb
-            </label>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top"
-                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 50000, 1] | max) }}-{{ '{:,}'.format(pos + 50000) }}">
-              <input type="radio" name="tss-options" autocomplete=off value="50000"> ±50kb
-            </label>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top"
-                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 100000, 1] | max) }}-{{ '{:,}'.format(pos + 100000) }}">
-              <input type="radio" name="tss-options" autocomplete=off value="100000"> ±100kb
-            </label>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top"
-                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 200000, 1] | max) }}-{{ '{:,}'.format(pos + 200000) }}">
-              <input type="radio" name="tss-options" autocomplete=off value="200000"> ±200kb
-            </label>
-            <label class="btn btn-info" data-toggle="tooltip" data-placement="top"
-                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 500000, 1] | max) }}-{{ '{:,}'.format(pos + 500000) }}">
-              <input type="radio" name="tss-options" autocomplete=off value="500000"> ±500kb
-            </label>
-            <label class="btn btn-info active" data-toggle="tooltip" data-placement="top"
-                   title="Show eQTLs for genes with TSS in the range chr{{ chrom }}:{{ '{:,}'.format([pos - 1000000, 1] | max) }}-{{ '{:,}'.format(pos + 1000000) }}">
-              <input type="radio" name="tss-options" autocomplete=off value="1000000"> ±1mb
-            </label>
-
-          </div>
-        </form>
-      </div>
-    </div>
-
-    <div id="lz-plot"></div>
-
-    <div class="container-fluid">
-      <div class="row justify-content-center">
-    <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
-          title="The red dotted line indicates the current variant's position with respect to the scale on the gene track.">
-      <span class="badge badge-pill badge-secondary" style="pointer-events: none;"><span class="fa fa-question"></span> Red dotted line </span>
-    </span>
-      </div>
-    </div>
-
+  </div>
+  
+  <div class="container-fluid">
     <div id="table" style="width:90%;margin:0 auto"></div>
-
     <!-- Supporting information about this project -->
     <div class="card">
       <div class="card-body">

--- a/pheget/frontend/templates/frontend/variant.html
+++ b/pheget/frontend/templates/frontend/variant.html
@@ -2,7 +2,6 @@
 
 {% block title %}Variant{% endblock %}
 
-
 {% block css %}
   <!-- Allows text wrapping in Tabulator title text. Reference: https://github.com/olifolkerd/tabulator/issues/988 -->
   <style>
@@ -52,13 +51,14 @@
 
   <div class="container-fluid">
     <div class="row justify-content-start">
+
       <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
         <form class="grouping" id="grouping-buttons">
           <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
-                title="Reorder the x-axis by one of these listed categories" data-placement="top">
-            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-exchange-alt"></span> Group by: </button>
-          </span>
+            <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                  title="Reorder the x-axis by one of these listed categories" data-placement="top">
+              <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-exchange-alt"></span> Group by: </button>
+            </span>
             <label class="btn btn-secondary" data-toggle="tooltip" data-placement="top"
                    title="Group eQTLs by tissues, sorted alphabetically">
               <input type="radio" name="group-options" autocomplete=off value="tissue"> Tissue
@@ -78,10 +78,10 @@
       <div class="col-12 col-lg-4" style="margin-bottom:0.8em">
         <form class="yaxis-display" id="transform-y">
           <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
-                title="Switches the variable plotted on the Y-axis between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
-            <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
-          </span>
+            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-html="true"
+                  title="Switches the variable plotted on the Y-axis between -log<sub>10</sub>(P-value) and Normalized Effect Size (NES). Triangles indicate eQTLs for upregulation (pointing up) or downregulation (pointing down) of gene expression with P-values < 0.05.">
+              <button type="button" class="btn btn-outline-secondary" style="pointer-events: none;"> <span class="fa fa-arrows-alt-v"></span> Show on Y-Axis: </button>
+            </span>
             <label class="btn btn-secondary active" data-toggle="tooltip" data-placement="top" data-html="true"
                    title="Display -log<sub>10</sub>(P-values) on the Y-axis">
               <input type="radio" name="y-options" autocomplete=off value="log_pvalue"> P-values
@@ -159,7 +159,8 @@
   </div>
 
   <div class="container-fluid">
-    <div id="lz-plot"></div>
+    <div id="lz-plot">
+    </div>
   </div>
   
   <div class="container-fluid">
@@ -298,8 +299,12 @@
   </div>
   
   <div class="container-fluid">
-    <div id="table" style="width:90%;margin:0 auto"></div>
-    <!-- Supporting information about this project -->
+    <div id="table" style="width:90%;margin:0 auto">
+    </div>
+  </div>
+
+  <!-- Supporting information about this project -->
+  <div class="container-fluid">
     <div class="card">
       <div class="card-body">
         <a href="https://www.gtexportal.org/home/datasets" class="badge badge-pill badge-secondary"
@@ -310,12 +315,11 @@
            data-toggle="tooltip" data-placement="top"
            title="Normalized Effect Size (NES) is defined as the effect of one allele on the inverse-normalized expression level of the associated gene. Follow this link for more details from the GTEx Portal.">
           Definition of NES <span class="fa fa-external-link-alt"></span> </a>
-        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
-              title="Created by Alan Kwong, Mukai Wang, Andy Boughton, Peter VandeHaar, and Hyun Min Kang">
+        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top" data-html="true"
+              title="Created by Alan Kwong, Mukai Wang, Andy Boughton, Peter VandeHaar, and Hyun Min Kang. Source code can be found on <a href=https://github.com/statgen/pheget/>GitHub</a>.">
         <span class="badge badge-pill badge-secondary" style="pointer-events: none;"><span
             class="fa fa-lightbulb-o"></span> Credits </span>
       </span>
-
       </div>
     </div>
   </div>

--- a/pheget/static/js/region.js
+++ b/pheget/static/js/region.js
@@ -71,6 +71,11 @@ function getTrackLayout(gene_id, tissue, state, genesymbol) {
     const layoutBase =
         LocusZoom.Layouts.get('panel', 'association', {
             id: `assoc_${tissue}_${geneid_short}`,
+            title: {  // Remove this when LocusZoom update with the fix to dashboard titles is published
+                text: `${genesymbol} in ${tissue}`,
+                x: 60,
+                y: 30
+            },
             namespace,
             data_layers: [
                 LocusZoom.Layouts.get('data_layer', 'significance', { unnamespaced: true }),
@@ -79,6 +84,7 @@ function getTrackLayout(gene_id, tissue, state, genesymbol) {
             ]
         });
 
+    /* Add this back in when LocusZoom update is published
     layoutBase.dashboard.components.push(
         {
             type: 'title',
@@ -86,6 +92,7 @@ function getTrackLayout(gene_id, tissue, state, genesymbol) {
             position: 'left'
         }
     );
+    */
 
     return [layoutBase];
 }

--- a/pheget/static/js/region.js
+++ b/pheget/static/js/region.js
@@ -71,7 +71,16 @@ function getTrackLayout(gene_id, tissue, state, genesymbol) {
     return [
         LocusZoom.Layouts.get('panel', 'association', {
             id: `assoc_${tissue}_${geneid_short}`,
-            //title: { text: `Association between ${tissue} and ${genesymbol}`, x: 100, y: 30 },  // TODO: Use gene symbol instead of gene id
+            title: { text: `${genesymbol} in ${tissue}`, x: 100, y: 30 },  // TODO: Use gene symbol instead of gene id
+            // dashboard: {
+            //     components: [
+            //         {
+            //             type: 'title',
+            //             title: `<i>${genesymbol}</i> in ${tissue}`,
+            //             position: 'left'
+            //         }
+            //     ]
+            // },  // Adding this makes the text auto-hide initially, but adds extra copies on mouse hover
             namespace,
             data_layers: [
                 LocusZoom.Layouts.get('data_layer', 'significance', { unnamespaced: true }),

--- a/pheget/static/js/region.js
+++ b/pheget/static/js/region.js
@@ -45,7 +45,8 @@ function getTrackSources(gene_id, tissue) {
  * @param {object} state
  * @returns {[*]}
  */
-function getTrackLayout(gene_id, tissue, state) {
+function getTrackLayout(gene_id, tissue, state, genesymbol) {
+    genesymbol = genesymbol || gene_id;
     const geneid_short = gene_id.split('.')[0];
 
     const newscattertooltip = LocusZoom.Layouts.get('data_layer', 'association_pvalues', { unnamespaced: true }).tooltip;
@@ -75,7 +76,7 @@ function getTrackLayout(gene_id, tissue, state) {
     return [
         LocusZoom.Layouts.get('panel', 'association', {
             id: `assoc_${tissue}_${geneid_short}`,
-            title: { text: `Association between ${tissue} and ${geneid_short}`, x: 100, y: 30 },  // TODO: Use gene symbol instead of gene id
+            //title: { text: `Association between ${tissue} and ${genesymbol}`, x: 100, y: 30 },  // TODO: Use gene symbol instead of gene id
             namespace,
             data_layers: [
                 LocusZoom.Layouts.get('data_layer', 'significance', { unnamespaced: true }),
@@ -175,11 +176,11 @@ function addPanels(plot, data_sources, panel_options, source_options) {
  * @returns {[LocusZoom.Plot, LocusZoom.DataSources]}
  */
 // eslint-disable-next-line no-unused-vars
-function makeSinglePlot(gene_id, tissue, selector) {
+function makeSinglePlot(gene_id, tissue, selector, genesymbol) {
     const stateUrlMapping = {chr: 'chrom', start: 'start', end: 'end'};
     // The backend guarantees that these params will be part of the URL on pageload
     const initialState = LocusZoom.ext.DynamicUrls.paramsFromUrl(stateUrlMapping);
-    const track_panels = getTrackLayout(gene_id, tissue, initialState);
+    const track_panels = getTrackLayout(gene_id, tissue, initialState, genesymbol);
     const base_layout = getBasicLayout(initialState, track_panels);
 
     const track_sources = getTrackSources(gene_id, tissue);
@@ -204,8 +205,8 @@ function makeSinglePlot(gene_id, tissue, selector) {
  * @param {string} tissue
  */
 // eslint-disable-next-line no-unused-vars
-function addTrack(plot, datasources, gene_id, tissue) {
-    const track_layout = getTrackLayout(gene_id, tissue, plot.state);
+function addTrack(plot, datasources, gene_id, tissue, genesymbol) {
+    const track_layout = getTrackLayout(gene_id, tissue, plot.state, genesymbol);
     const track_sources = getTrackSources(gene_id, tissue);
     addPanels(plot, datasources, track_layout, track_sources);
 }

--- a/pheget/static/js/region.js
+++ b/pheget/static/js/region.js
@@ -68,27 +68,26 @@ function getTrackLayout(gene_id, tissue, state, genesymbol) {
         tooltip: newscattertooltip
     });
 
-    return [
+    const layoutBase =
         LocusZoom.Layouts.get('panel', 'association', {
             id: `assoc_${tissue}_${geneid_short}`,
-            title: { text: `${genesymbol} in ${tissue}`, x: 100, y: 30 },  // TODO: Use gene symbol instead of gene id
-            // dashboard: {
-            //     components: [
-            //         {
-            //             type: 'title',
-            //             title: `<i>${genesymbol}</i> in ${tissue}`,
-            //             position: 'left'
-            //         }
-            //     ]
-            // },  // Adding this makes the text auto-hide initially, but adds extra copies on mouse hover
             namespace,
             data_layers: [
                 LocusZoom.Layouts.get('data_layer', 'significance', { unnamespaced: true }),
                 LocusZoom.Layouts.get('data_layer', 'recomb_rate', { unnamespaced: true }),
                 assoc_layer,
             ]
-        })
-    ];
+        });
+
+    layoutBase.dashboard.components.push(
+        {
+            type: 'title',
+            title: `<i>${genesymbol}</i> in ${tissue}`,
+            position: 'left'
+        }
+    );
+
+    return [layoutBase];
 }
 
 /**


### PR DESCRIPTION
## Ticket
n/a

## Purpose
More updates for the UI, mainly to tone down the colors on the buttons and move parts around to make the more important components stand out more (i.e. the main association plots). Also updates the region plot's title (temporary fix until LocusZoom update is published; we will want to update it back to using the title text after https://github.com/statgen/locuszoom/issues/176 is addressed).

## How to test this
In the region view, change anchor gene and tissue, and add new genes and tissues to ensure correct behavior; in the single-variant view, click all the buttons to make sure they still work as expected.

## Deployment / configuration notes
(none)
