### PR TITLE
Change search behavior

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,7 @@
         "eol-last": "error"
     },
     "env": {
+        "es6": true,
         "browser": true
     }
 }

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -19,9 +19,6 @@ def gene_query(symbol: str):
     """
     Given a gene, query an SQL database to find the variant with the strongest association with that gene
     """
-    # ~UGLY HACK~ If omnisearch did not return a gene_id, then searchbox will fill in "undefined" - immediately abort in that case
-    if symbol == "undefined":
-        abort(404)
     # Instead of querying locally, I will use omnisearch to get the relevant parameters (chrom, pos, gene_id)
     url = f"https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q={symbol}&build=GRCh38"
     omniJson = json.load(urllib.request.urlopen(url))["data"][0]

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -14,7 +14,7 @@ from .format import query_variants
 api_blueprint = Blueprint("api", __name__)
 
 
-@api_blueprint.route("/<string:symbol>/bestvar/", methods=["GET"])
+@api_blueprint.route("/gene/<string:symbol>/bestvar/", methods=["GET"])
 def gene_query(symbol: str):
     """
     Given a gene, query an SQL database to find the variant with the strongest association with that gene

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -19,6 +19,9 @@ def gene_query(symbol: str):
     """
     Given a gene, query an SQL database to find the variant with the strongest association with that gene
     """
+    # ~UGLY HACK~ If omnisearch did not return a gene_id, then searchbox will fill in "undefined" - immediately abort in that case
+    if symbol == "undefined":
+        abort(404)
     # Instead of querying locally, I will use omnisearch to get the relevant parameters (chrom, pos, gene_id)
     url = f"https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q={symbol}&build=GRCh38"
     omniJson = json.load(urllib.request.urlopen(url))["data"][0]
@@ -46,7 +49,7 @@ def gene_query(symbol: str):
                             "chr" + omniJson["chrom"],
                             omniJson["start"] - 1000000,
                             omniJson["end"] + 1000000,
-                            omniJson["gene_id"].split(".")[0] + ".%",
+                            omniJson["gene_id"].split(".")[0] + "._%",
                         ),
                     )
                 )[

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -14,13 +14,12 @@ from .format import query_variants
 api_blueprint = Blueprint("api", __name__)
 
 
-# Returns all eQTL data given a positional range, optionally filtering by tissue and gene_id
 @api_blueprint.route(
     "/region/<string:chrom>/<int:start>-<int:end>/", methods=["GET"]
 )
 def region_query(chrom, start, end):
     """
-    Fetch the data for a given region
+    Fetch the eQTL data for a given region, optionally filtering by tissue and gene_id
 
     In its current form, this allows fetching ALL points across any gene and tissue. We may wish to revisit this
     due to performance considerations. (FIXME)
@@ -43,13 +42,15 @@ def region_query(chrom, start, end):
     return jsonify(results)
 
 
-# Given a chromosome and positional range, returns the tissue with the strongest single eQTL signal,
-#  along with gene symbol and gene_id. This is queried when a user enters chr:start-end directly
-#  to find the best tissue and gene within the provided query.
 @api_blueprint.route(
     "/region/<string:chrom>/<int:start>-<int:end>/best/", methods=["GET"]
 )
-def best_range_query(chrom: str, start: int, end: int):
+def region_query_bestvar(chrom: str, start: int, end: int):
+    """
+    Given a region, returns the tissue with the strongest single eQTL signal, along with gene symbol and gene_id.
+
+    Optionally, a gene_id can be specified as query param, in which it will get the best signal within that gene.
+    """
     gene_id = request.args.get("gene_id", None)
     if gene_id is None:
         url = f"https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q={gene_id}&build=GRCh38"

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -14,63 +14,6 @@ from .format import query_variants
 api_blueprint = Blueprint("api", __name__)
 
 
-# When given a gene name (symbol or ENSG...), return the chrom:pos of the variant with the strongest eQTL signal
-#  along with the associated tissue
-@api_blueprint.route("/gene/<string:symbol>/bestvar/", methods=["GET"])
-def gene_query(symbol: str):
-    """
-    Given a gene, query an SQL database to find the variant and tissue with the strongest association with that gene
-    """
-    # Instead of querying locally, I will use omnisearch to get the relevant parameters (chrom, pos, gene_id)
-    url = f"https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q={symbol}&build=GRCh38"
-    omniJson = json.load(urllib.request.urlopen(url))["data"][0]
-    if (
-        "gene_id" in omniJson
-        and "chrom" in omniJson
-        and "start" in omniJson
-        and "end" in omniJson
-    ):
-        conn = sqlite3.connect(model.get_sig_lookup())
-        with conn:
-            try:
-                (
-                    sqlgene_id,
-                    sqlchrom,
-                    sqlpos,
-                    sqlref,
-                    sqlalt,
-                    sqlval,
-                    sqltissue,
-                ) = list(
-                    conn.execute(
-                        f"SELECT * FROM sig WHERE chrom=? AND pos >= ? AND pos <= ? AND gene_id LIKE ? ORDER BY pval LIMIT 1;",
-                        (
-                            "chr" + omniJson["chrom"],
-                            omniJson["start"] - 1000000,
-                            omniJson["end"] + 1000000,
-                            omniJson["gene_id"].split(".")[0] + "._%",
-                        ),
-                    )
-                )[
-                    0
-                ]
-                data = {
-                    "chrom": sqlchrom,
-                    "pos": sqlpos,
-                    "ref": sqlref,
-                    "alt": sqlalt,
-                    "tissue": sqltissue,
-                    "symbol": omniJson["gene_name"],
-                    "gene_id": omniJson["gene_id"],
-                }
-                results = {"data": data}
-                return jsonify(results)
-            except IndexError:
-                abort(404)
-    else:
-        abort(404)
-
-
 # Returns all eQTL data given a positional range, optionally filtering by tissue and gene_id
 @api_blueprint.route(
     "/region/<string:chrom>/<int:start>-<int:end>/", methods=["GET"]
@@ -107,42 +50,74 @@ def region_query(chrom, start, end):
     "/region/<string:chrom>/<int:start>-<int:end>/best/", methods=["GET"]
 )
 def best_range_query(chrom: str, start: int, end: int):
+    gene_id = request.args.get("gene_id", None)
+    if gene_id is None:
+        url = f"https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q={gene_id}&build=GRCh38"
+        omniJson = json.load(urllib.request.urlopen(url))["data"][0]
+        if "gene_id" in omniJson:
+            gene_id = omniJson["gene_id"]
     gene_json = model.get_gene_names_conversion()
     if chrom is not None and chrom[0:3] == "chr":
         chrom = chrom[3:]
     if chrom is not None and start is not None and end is not None:
         conn = sqlite3.connect(model.get_sig_lookup())
         with conn:
-            try:
-                (
-                    sqlgene_id,
-                    sqlchrom,
-                    sqlpos,
-                    sqlref,
-                    sqlalt,
-                    sqlval,
-                    sqltissue,
-                ) = list(
-                    conn.execute(
-                        f"SELECT * FROM sig WHERE chrom=? AND pos >= ? AND pos <= ? ORDER BY pval LIMIT 1;",
-                        ("chr" + chrom, start, end,),
-                    )
-                )[
-                    0
-                ]
-                data = {
-                    "chrom": sqlchrom,
-                    "pos": sqlpos,
-                    "ref": sqlref,
-                    "alt": sqlalt,
-                    "tissue": sqltissue,
-                    "gene_id": sqlgene_id,
-                    "symbol": gene_json.get(sqlgene_id.split(".")[0], ""),
-                }
-                results = {"data": data}
-                return jsonify(results)
-            except IndexError:
-                abort(404)
+            if gene_id is None:
+                try:
+                    (
+                        sqlgene_id,
+                        sqlchrom,
+                        sqlpos,
+                        sqlref,
+                        sqlalt,
+                        sqlval,
+                        sqltissue,
+                    ) = list(
+                        conn.execute(
+                            f"SELECT * FROM sig WHERE chrom=? AND pos >= ? AND pos <= ? ORDER BY pval LIMIT 1;",
+                            ("chr" + chrom, start, end,),
+                        )
+                    )[
+                        0
+                    ]
+                except IndexError:
+                    abort(404)
+            else:
+                try:
+                    (
+                        sqlgene_id,
+                        sqlchrom,
+                        sqlpos,
+                        sqlref,
+                        sqlalt,
+                        sqlval,
+                        sqltissue,
+                    ) = list(
+                        conn.execute(
+                            f"SELECT * FROM sig WHERE chrom=? AND pos >= ? AND pos <= ? AND gene_id LIKE ? ORDER BY pval LIMIT 1;",
+                            (
+                                "chr" + chrom,
+                                start,
+                                end,
+                                gene_id.split(".")[0] + "._%",
+                            ),
+                        )
+                    )[
+                        0
+                    ]
+                except IndexError:
+                    abort(404)
+            data = {
+                "chrom": sqlchrom,
+                "pos": sqlpos,
+                "ref": sqlref,
+                "alt": sqlalt,
+                "tissue": sqltissue,
+                "gene_id": sqlgene_id,
+                "symbol": gene_json.get(sqlgene_id.split(".")[0], ""),
+            }
+            results = {"data": data}
+            return jsonify(results)
     else:
         abort(404)
 

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -14,7 +14,7 @@ from .format import query_variants
 api_blueprint = Blueprint("api", __name__)
 
 
-@api_blueprint.route("/bestvar/<string:symbol>/", methods=["GET"])
+@api_blueprint.route("/<string:symbol>/bestvar/", methods=["GET"])
 def gene_query(symbol: str):
     """
     Given a gene, query an SQL database to find the variant with the strongest association with that gene

--- a/pheget/frontend/templates/frontend/region.html
+++ b/pheget/frontend/templates/frontend/region.html
@@ -32,7 +32,7 @@
 
     <br>
     {#  FIXME: This label does not update as the plot is panned or zoomed. We can resolve this in the future when we move to a dynamic frontend #}
-    <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs in {{ chrom }}:{{ "{:,}".format(start) }}-{{ "{:,}".format(end) }} </strong></h1>
+    <h1 style="margin-top: 1em;"><strong>Single-tissue eQTLs near <span id="header-symbol">{{ symbol }}</span> (chr{{ chrom }}:{{ "{:,}".format(start) }}-{{ "{:,}".format(end) }}) </strong></h1>
   </div>
 
   <div class="container-fluid">
@@ -160,13 +160,66 @@
 
 <br>
 
+<!-- 
+  Since these links are based on Jinja template values, they currently do not update when we change anchor genes.
+  We plan to update the mechanism handling URLs so that when you change the anchor gene, you are redirected to a new page.
+  This will allow these links to update correctly when changing the anchor gene.
+-->
 <div class="container-fluid">
   <div class="card">
-    <div class="card-body">
+    <div class="row">
+      <div class="col">
+        <div class="card-body">
+          <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
+            title="External links for more information about this gene">
+          <button class="btn btn-sm btn-secondary" style="pointer-events: none;"><span
+            class="fa fa-secondary-circle"></span><span class="fa fa-info-circle"></span> More info about {{ symbol }} </button>
+          </span>
+          {% set short_gene_id = gene_id.split('.')[0] %}
+          <a href="https://bravo.sph.umich.edu/freeze5/hg38/gene/{{ short_gene_id }}" target="_blank"
+              class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+              data-placement="top" data-html=true
+              title="Gene information from NHLBI's TOPMed program, containing 463 million variants observed in 62,784 individuals in data freeze 5. <b>Requires Google login</b>">
+            BRAVO <span class="fa fa-external-link-alt"></span> </a>          
+          <a href="https://gtexportal.org/home/gene/{{ symbol }}" target="_blank"
+              class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+              data-placement="top" data-html=true
+              title="Detailed information from the GTEx Portal, including both gene and exon expression, along with single-tissue eQTLs and sQTLs.">
+            GTEx Portal <span class="fa fa-external-link-alt"></span> </a>
+          <a href="https://gnomad.broadinstitute.org/gene/{{ symbol }}?dataset=gnomad_r3" target="_blank"
+              class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
+              data-placement="top"
+              title="The Genome Aggregation Database (v3) at the Broad Institute, containing variant data from 71,702 sequenced genomes">
+            gnomAD <span class="fa fa-external-link-alt"></span></a>
+          <a href="http://pheweb.sph.umich.edu/gene/{{ symbol }}" target="_blank" class="btn btn-secondary btn-sm" role="button"
+              aria-pressed="true" data-toggle="tooltip" data-placement="top"
+              title="PheWeb summary of association results from 1,448 electronic health record-derived phenotypes tested against up to ~6,000 cases and ~18,000 controls with genotyped and imputed samples from the Michigan Genomics Initiative">
+            MGI <span class="fa fa-external-link-alt"></span></a>
+          <a href="http://pheweb.sph.umich.edu/SAIGE-UKB/gene/{{ symbol }}" target="_blank" class="btn btn-secondary btn-sm"
+              role="button" aria-pressed="true" data-toggle="tooltip" data-placement="top"
+              title="PheWeb summary of association results from the UK Biobank, with up to ~78k cases and ~409k controls, with binary outcomes analyzed with the SAIGE software">
+            UKB-SAIGE <span class="fa fa-external-link-alt"></span></a>
+          <a href="http://big.stats.ox.ac.uk/gene/{{ symbol }}" target="_blank" class="btn btn-secondary btn-sm" role="button"
+              aria-pressed="true" data-toggle="tooltip" data-placement="top"
+              title="Summary of 3,144 GWAS of Brain Imaging Derived Phenotypes (IDPs) in 9,707 participants from the UK Biobank, analyzed with the BGENIE software">
+            UKB-Oxford BIG <span class="fa fa-external-link-alt"></span></a>
+          <a href="http://www.ebi.ac.uk/gxa/search?geneQuery=[{'value':'{{symbol}}'}]" target="_blank" class="btn btn-secondary btn-sm" role="button"
+              aria-pressed="true" dadta-toggle="tooltip" data-placement="top"
+              title="The Expression Atlas is a project from the European Bioinformatics Institute (EMBL-EBI), with results from over 3,000 experiments from 40 different organisms, which have been manually reviewed, curated, and standardized.">
+             Expression Atlas <span class="fa fa-external-link-alt"></span></a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container-fluid">
+  <div class="row">
+    <div class="col">
       <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top" data-html="true"
-        title="Created by Alan Kwong, Mukai Wang, Andy Boughton, Peter VandeHaar, and Hyun Min Kang. Source code can be found on <a href=https://github.com/statgen/pheget/>GitHub</a>.">
+          title="Created by Alan Kwong, Mukai Wang, Andy Boughton, Peter VandeHaar, and Hyun Min Kang. Source code can be found on <a href=https://github.com/statgen/pheget/>GitHub</a>.">
         <span class="badge badge-pill badge-secondary" style="pointer-events: none;">
-          <span class="fa fa-lightbulb-o"></span> Credits
+        <span class="fa fa-lightbulb-o"></span> Credits
         </span>
       </span>
     </div>
@@ -249,7 +302,8 @@
             ANCHOR_GENE = event.currentTarget.dataset.geneid;
             ANCHOR_SYMBOL = event.currentTarget.dataset.genesymbol;
             document.querySelector('.anchorgene').innerHTML = GENE_DICT[ANCHOR_GENE];
-            document.querySelector('.anchor-gene-label').innerHTML = GENE_DICT[ANCHOR_GENE]
+            document.querySelector('.anchor-gene-label').innerHTML = GENE_DICT[ANCHOR_GENE];
+            document.getElementById('header-symbol').innerHTML = GENE_DICT[ANCHOR_GENE];
             let panel_ids = Array.from(plot.layout.panels, panel => panel.id);
             panel_ids.forEach(function(id){
               if (id !=='genes'){

--- a/pheget/frontend/templates/frontend/variant.html
+++ b/pheget/frontend/templates/frontend/variant.html
@@ -257,43 +257,43 @@
               <span class="d-inline-block" tabindex="0" data-toggle="tooltip" data-placement="top"
                     title="External links for more information about this variant">
                 <button class="btn btn-sm btn-secondary" style="pointer-events: none;"><span
-                    class="fa fa-secondary-circle"></span> Variant info </button>
+                    class="fa fa-secondary-circle"></span><span class="fa fa-info-circle"></span> Variant info </button>
               </span>
               {% if ref is not none and alt is not none %}
-                <a href="https://bravo.sph.umich.edu/freeze5/hg38/variant/{{ chrom }}-{{ pos }}-{{ ref }}-{{ alt }}"
+                <a href="https://bravo.sph.umich.edu/freeze5/hg38/variant/{{ chrom }}-{{ pos }}-{{ ref }}-{{ alt }}" target="_blank"
                     class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
                     data-placement="top" data-html=true
                     title="Variant data from NHLBI's TOPMed program, containing 463 million variants observed in 62,784 individuals in data freeze 5. <b>Requires Google login</b>">
                   BRAVO <span class="fa fa-external-link-alt"></span> </a>
-                <a href="https://gtexportal.org/home/snp/chr{{ chrom }}_{{ pos }}_{{ ref }}_{{ alt }}_b38"
+                <a href="https://gtexportal.org/home/snp/chr{{ chrom }}_{{ pos }}_{{ ref }}_{{ alt }}_b38" target="_blank"
                     class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
                     data-placement="top"
                     title="Variant data from the Genotype-Tissue Expression project, containing expression data, histology images, and in-depth expression data analysis">
                   GTEx Portal <span class="fa fa-external-link-alt"></span> </a>
-                <a href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr{{ chrom }}%3A{{ pos }}-{{ pos }}&position=chr{{ chrom }}%3A{{ pos - 25 }}-{{ pos + 25 }}"
+                <a href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&highlight=hg38.chr{{ chrom }}%3A{{ pos }}-{{ pos }}&position=chr{{ chrom }}%3A{{ pos - 25 }}-{{ pos + 25 }}" target="_blank"
                     class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
                     data-placement="top" title="The UC Santa Cruz Genome Browser"> UCSC <span
                     class="fa fa-external-link-alt"></span></a>
-                <a href="https://gnomad.broadinstitute.org/variant/{{ chrom }}-{{ pos }}-{{ ref }}-{{ alt }}?dataset=gnomad_r3"
+                <a href="https://gnomad.broadinstitute.org/variant/chr{{ chrom }}-{{ pos }}-{{ ref }}-{{ alt }}?dataset=gnomad_r3" target="_blank"
                     class="btn btn-secondary btn-sm" role="button" aria-pressed="true" data-toggle="tooltip"
                     data-placement="top"
                     title="The Genome Aggregation Database (v3) at the Broad Institute, containing variant data from 71,702 sequenced genomes">
                   gnomAD <span class="fa fa-external-link-alt"></span></a>
               {% endif %}
               {% if rsid is not none %}
-                <a href="https://www.ncbi.nlm.nih.gov/snp/{{ rsid }}" class="btn btn-secondary btn-sm" role="button"
+                <a href="https://www.ncbi.nlm.nih.gov/snp/{{ rsid }}" target="_blank" class="btn btn-secondary btn-sm" role="button"
                     aria-pressed="true" data-toggle="tooltip" data-placement="top"
                     title="Reference SNP Report from the National Center for Biotechnology Information (NCBI)"> dbSNP
                   <span class="fa fa-external-link-alt"></span> </a>
-                <a href="http://pheweb.sph.umich.edu/go?query={{ rsid }}" class="btn btn-secondary btn-sm" role="button"
+                <a href="http://pheweb.sph.umich.edu/go?query={{ rsid }}" target="_blank" class="btn btn-secondary btn-sm" role="button"
                     aria-pressed="true" data-toggle="tooltip" data-placement="top"
                     title="PheWeb summary of association results from 1,448 electronic health record-derived phenotypes tested against up to ~6,000 cases and ~18,000 controls with genotyped and imputed samples from the Michigan Genomics Initiative">
                   MGI <span class="fa fa-external-link-alt"></span></a>
-                <a href="http://pheweb.sph.umich.edu/SAIGE-UKB/go?query={{ rsid }}" class="btn btn-secondary btn-sm"
+                <a href="http://pheweb.sph.umich.edu/SAIGE-UKB/go?query={{ rsid }}" target="_blank" class="btn btn-secondary btn-sm"
                     role="button" aria-pressed="true" data-toggle="tooltip" data-placement="top"
                     title="PheWeb summary of association results from the UK Biobank, with up to ~78k cases and ~409k controls, with binary outcomes analyzed with the SAIGE software">
                   UKB-SAIGE <span class="fa fa-external-link-alt"></span></a>
-                <a href="http://big.stats.ox.ac.uk/go?query={{ rsid }}" class="btn btn-secondary btn-sm" role="button"
+                <a href="http://big.stats.ox.ac.uk/go?query={{ rsid }}" target="_blank" class="btn btn-secondary btn-sm" role="button"
                     aria-pressed="true" data-toggle="tooltip" data-placement="top"
                     title="Summary of 3,144 GWAS of Brain Imaging Derived Phenotypes (IDPs) in 9,707 participants from the UK Biobank, analyzed with the BGENIE software">
                   UKB-Oxford BIG <span class="fa fa-external-link-alt"></span></a>

--- a/pheget/settings/base.py
+++ b/pheget/settings/base.py
@@ -22,7 +22,7 @@ PHEGET_DATA_DIR = os.getenv(
     ),
 )
 
-LOCUSZOOM_VERSION = "0.10.1"
+LOCUSZOOM_VERSION = "0.10.2"
 
 # .env file can optionally provide a Sentry key for automatic error reporting
 # TODO: add for frontend and backend

--- a/pheget/static/js/region.js
+++ b/pheget/static/js/region.js
@@ -2,7 +2,7 @@
 
 const API_BASE = 'https://portaldev.sph.umich.edu/api/v1/';
 // Set to smaller values for testing; go up to 50k or 200k after we make it more efficient
-const MAX_EXTENT = 500000;
+const MAX_EXTENT = 1000000;
 
 
 LocusZoom.Data.assocGET = LocusZoom.KnownDataSources.extend('AssociationLZ', 'assocGET', {

--- a/pheget/static/js/region.js
+++ b/pheget/static/js/region.js
@@ -237,8 +237,9 @@ function addTrack(plot, datasources, gene_id, tissue, genesymbol) {
  */
 // eslint-disable-next-line no-unused-vars
 function switchY_region(plot, yfield) {
-    let assoc_panels = plot.layout.panels;  // Iterate through all panels, including any added panels
-    assoc_panels.forEach(function (panel) {
+    // Iterate through all panels, including any added panels
+    Object.keys(plot.panels).forEach(function (panel_id) {
+        const panel = plot.panels[panel_id].layout;
         if (panel.data_layers.some(d => d.id === 'associationpvalues') && panel.data_layers.some(d => d.id === 'significance')) {
             let scatter_layout = panel.data_layers.find(d => d.id === 'associationpvalues');
             let panel_base_y = scatter_layout.y_axis;
@@ -278,7 +279,7 @@ function switchY_region(plot, yfield) {
                     { shape: 'circle', color: '#357ebd', size: 40, label: '0.2 > r² ≥ 0.0', class: 'lz-data_layer-scatter' },
                     { shape: 'circle', color: '#B8B8B8', size: 40, label: 'no r² data', class: 'lz-data_layer-scatter' }
                 ];
-                for (let panel of Object.values(plot.panels)) {if (panel.legend) {panel.legend.hide();}}
+                plot.panels[panel_id].legend.hide();
             } else if (yfield === 'log_pvalue') {  // Settings for using -log10(P-value) as the y-axis variable
                 delete panel.axes.y1.ticks;
                 panel.legend.orientation = 'vertical';
@@ -314,7 +315,7 @@ function switchY_region(plot, yfield) {
                     { shape: 'circle', color: '#357ebd', size: 40, label: '0.2 > r² ≥ 0.0', class: 'lz-data_layer-scatter' },
                     { shape: 'circle', color: '#B8B8B8', size: 40, label: 'no r² data', class: 'lz-data_layer-scatter' }
                 ];
-                for (let panel of Object.values(plot.panels)) {if (panel.legend) {panel.legend.hide();}}
+                plot.panels[panel_id].legend.hide();
             } else if (yfield === 'pip') {
                 panel.legend.orientation = 'horizontal';
                 panel.legend.pad_from_bottom = 46;
@@ -358,7 +359,7 @@ function switchY_region(plot, yfield) {
                     'stroke-dasharray': '10px 0px'
                 };
                 panel_base_y.min_extent = [0, 1];
-                for (let panel of Object.values(plot.panels)) {if (panel.legend) {panel.legend.show();}}
+                plot.panels[panel_id].legend.show();
             } else {
                 throw new Error('Unrecognized yfield option');
             }

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -108,6 +108,15 @@ function parseSearchText(searchText) {
                         const { symbol, tissue } = bestRangeResult;
                         const { chrom, start, end } = omni;
                         return { type: 'range', chrom, start, end, gene_id: gene_id, symbol, tissue };
+                    })
+                    .catch(function() {
+                        return getBestRange(chrom, start, end)
+                            .then(function(bestRangeResult) {
+                                const { symbol, gene_id, tissue } = bestRangeResult;
+                                const { chrom, start, end } = omni;
+                                alert('No significant eQTLs found for the query gene, redirecting to next best match.');
+                                return { type: 'range', chrom, start, end, gene_id: gene_id, symbol, tissue};
+                            });
                     });
             });
     }

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -26,7 +26,7 @@ function getOmniSearch(searchText) {
 function getBestRange(chrom, start, end, gene_id = null) {
     var bestURL = `/api/region/${chrom}/${start}-${end}/best/`;
     if (gene_id !== null) {
-        bestURL = bestURL + `?gene_id=${gene_id}`;
+        bestURL += `?gene_id=${gene_id}`;
     }
     return fetch(bestURL)
         .then(handleErrors)

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -4,10 +4,20 @@ function failureCallback(error) {
 }
 
 
+// Handles bad requests - copied from https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
+function handleErrors(response) {
+    if (!response.ok) {
+        throw Error(response.statusText);
+    }
+    return response;
+}
+
+
 // Returns the data from an omnisearch fetch if successful, return nothing otherwise
 function getOmniSearch(searchText) {
     const omniurl = `https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q=${searchText}&build=GRCh38`;
     var data = fetch(omniurl)
+        .then(handleErrors)
         .then((response) => response.json())
         .then((myJson) => myJson.data[0])
         .catch(function(error) {
@@ -22,6 +32,7 @@ function getOmniSearch(searchText) {
 function getBestVar(symbol) {
     const bestVarURL = `/api/bestvar/${symbol}`;
     var data = fetch(bestVarURL)
+        .then(handleErrors)
         .then((response) => response.json())
         .then((resp) => resp.data)
         .catch(failureCallback);

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -1,8 +1,6 @@
-// Generic failure callback function
-function failureCallback(error) {
-    console.log('Error status: ' + error);
-}
-
+/**
+ * Reusable code for searchbox widget
+ */
 
 // Handles bad requests - copied from https://www.tjvantoll.com/2015/09/13/fetch-and-errors/
 function handleErrors(response) {
@@ -16,15 +14,10 @@ function handleErrors(response) {
 // Returns the data from an omnisearch fetch if successful, return nothing otherwise
 function getOmniSearch(searchText) {
     const omniurl = `https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q=${searchText}&build=GRCh38`;
-    var data = fetch(omniurl)
+    return fetch(omniurl)
         .then(handleErrors)
         .then((response) => response.json())
-        .then((myJson) => myJson.data[0])
-        .catch(function(error) {
-            console.log('Omnisearch error, status code: ' + error);
-            return;
-        });
-    return data;
+        .then((myJson) => myJson.data[0]);
 }
 
 
@@ -35,12 +28,10 @@ function getBestRange(chrom, start, end, gene_id = null) {
     if (gene_id !== null) {
         bestURL = bestURL + `?gene_id=${gene_id}`;
     }
-    var data = fetch(bestURL)
+    return fetch(bestURL)
         .then(handleErrors)
         .then((response) => response.json())
-        .then((resp) => resp.data)
-        .catch(failureCallback);
-    return data;
+        .then((resp) => resp.data);
 }
 
 
@@ -48,6 +39,7 @@ function getBestRange(chrom, start, end, gene_id = null) {
 // We expect queries in the form of a single variant (chr:pos or rsnum), a range (chr:start-end), or a gene name (ENSG or symbol)
 // This function always returns a Promise, because parseSearch expects it
 function parseSearchText(searchText) {
+    searchText = searchText.trim();
     // Use regular expressions to match known patterns for single variant, range, and rs number
     const chromposPattern = /(chr)?([1-9][0-9]?|X|Y|MT):([1-9][0-9]*)/;
     const rangePattern = /(chr)?([1-9][0-9]?|X|Y|MT):([1-9][0-9]*)-([1-9][0-9]*)/;
@@ -57,88 +49,61 @@ function parseSearchText(searchText) {
     const cMatchRS = searchText.match(rsPattern);
     // If input is in 'chrom:pos' format (with or without 'chr'), return the position of the single variant
     // TODO: Show closest variant if specific variant does not exist
-    var returnJson;
-    var jsonPromise;
     if (cMatch !== null && searchText === cMatch[0]) {
         const chrom = cMatch[2];
         const pos = parseInt(cMatch[3]);
-        returnJson = {type: 'variant', chrom, start: pos, end: pos};
-        // Forcefully convert this return to a Promise to match the others
-        // eslint-disable-next-line no-undef
-        jsonPromise = new Promise((resolve) => {
-            resolve(returnJson);
-        });
-        return jsonPromise;
+        return Promise.resolve({ type: 'variant', chrom, start: pos, end: pos });
     } else if (cMatchRange !== null && searchText === cMatchRange[0]) {
         // If the query is a range in the form [chr]:[start]-[end], return the position of the range
         const chrom = cMatchRange[2];
         const start = parseInt(cMatchRange[3]);
         const end = parseInt(cMatchRange[4]);
-        var returnType = getBestRange(chrom, start, end)
+        return getBestRange(chrom, start, end)
             .then(function(result) {
                 var varData = result;
                 const gene_id = varData.gene_id;
                 const symbol = varData.symbol;
                 const tissue = varData.tissue;
-                var returnStatus = {type: 'range', chrom, start, end, gene_id, symbol, tissue};
-                return returnStatus;
-            })
-            .catch(failureCallback);
-        return returnType;
+                return { type: 'range', chrom, start, end, gene_id, symbol, tissue };
+            });
     } else if (cMatchRS !== null && searchText === cMatchRS[0]) {
         // If input is in rs# format, use omnisearch to convert to chrom:pos, then return the position
-        var rangeReturn = getOmniSearch(searchText)
+        return getOmniSearch(searchText)
             .then(function(result) {
-                var varData = result;
-                const chrom = varData.chrom;
-                const start = varData.start;
-                const end = varData.end;
-                var returnStatus = {type: 'variant', chrom, start, end};
-                return returnStatus;
-            })
-            .catch(failureCallback);
-        return rangeReturn;
+                const { chrom, start, end } = result;
+                return { type: 'variant', chrom, start, end };
+            });
     } else {
         // If input is a gene or some other unknown format, then look for the best eQTL signal for that gene
         // First, look up the search query on omnisearch
-        var jsonResult = getOmniSearch(searchText)
+        return getOmniSearch(searchText)
             .then(function(result) {
                 // Pass the gene_id (ENSG...) to the next step, if it exists
                 if (result.gene_id === undefined) {
                     return;
-                }
-                else {
+                } else {
                     const chrom = result.chrom;
                     const start = Math.max(result.start - 500000, 1);
                     const end = result.end + 500000;
                     const gene_id = result.gene_id;
-                    var omni = {chrom, start, end, gene_id};
-                    return omni;
+                    return { chrom, start, end, gene_id };
                 }
             })
             .then(function(omni) {
                 // If omnisearch finds a gene_id, then return the range of the gene +/- 500000 and send the user to the region view
-                // const gene_id = omni.gene_id;
-                // var returnStatus = getBestVar(gene_id)
-                const chrom = omni.chrom;
-                const start = omni.start;
-                const end = omni.end;
+                if (!omni) {
+                    // TODO: If the input is not recognizable as any format, and is not a gene, then we should show a user error message that the requested entity was not found
+                    return;
+                }
+                const { chrom, start, end } = omni;
                 const gene_id = omni.gene_id;
-                var returnStatus = getBestRange(chrom, start, end, gene_id)
+                return getBestRange(chrom, start, end, gene_id)
                     .then(function(bestVarResult) {
-                        const tissue = bestVarResult.tissue;
-                        const symbol = bestVarResult.symbol;
-                        const chrom = omni.chrom;
-                        const start = omni.start;
-                        const end = omni.end;
-                        var rangeData = {type: 'range', chrom, start, end, gene_id: gene_id, symbol, tissue};
-                        return rangeData;
-                    })
-                    .catch(failureCallback);
-                return returnStatus;
-            })
-            .catch(failureCallback);
-        return jsonResult;
+                        const { symbol, tissue } = bestVarResult;
+                        const { chrom, start, end } = omni;
+                        return { type: 'range', chrom, start, end, gene_id: gene_id, symbol, tissue };
+                    });
+            });
     }
 }
 
@@ -147,8 +112,7 @@ function parseSearch(searchText) {
     parseSearchText(searchText)
         .then(function(omniresult) {
             if (omniresult === undefined || omniresult.type === 'other' && omniresult.chrom === null && omniresult.start === null && omniresult.end === null) {
-                alert('Sorry, we are unable to parse your query.');
-                failureCallback('Omnisearch undefined or other');
+                throw new Error('Sorry, we are unable to parse your query.');
             } else {
                 return(omniresult);
             }
@@ -162,5 +126,8 @@ function parseSearch(searchText) {
                 window.location = `/region/?chrom=${chrom}&start=${result.start}&end=${result.end}&gene_id=${result.gene_id}&symbol=${result.symbol}&tissue=${result.tissue}`;
             }
         })
-        .catch(failureCallback);
+        .catch(err => {
+            alert(err.message);
+            console.log(err.message);
+        });
 }

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -30,7 +30,7 @@ function getOmniSearch(searchText) {
 
 // Returns the data from our internal best variant API by searching for the gene_id (ENSG...) or gene_name
 function getBestVar(symbol) {
-    const bestVarURL = `/api/${symbol}/bestvar/`;
+    const bestVarURL = `/api/gene/${symbol}/bestvar/`;
     var data = fetch(bestVarURL)
         .then(handleErrors)
         .then((response) => response.json())

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -5,9 +5,9 @@ function failureCallback(error) {
 
 
 // Returns the data from an omnisearch fetch if successful, return nothing otherwise
-async function getOmniSearch(searchText) {
+function getOmniSearch(searchText) {
     const omniurl = `https://portaldev.sph.umich.edu/api/v1/annotation/omnisearch/?q=${searchText}&build=GRCh38`;
-    let data = await fetch(omniurl)
+    var data = fetch(omniurl)
         .then((response) => response.json())
         .then((myJson) => myJson.data[0])
         .catch(function(error) {
@@ -19,18 +19,19 @@ async function getOmniSearch(searchText) {
 
 
 // Returns the data from our internal best variant API by searching for the gene_id (ENSG...) or gene_name
-async function getBestVar(symbol) {
+function getBestVar(symbol) {
     const bestVarURL = `/api/bestvar/${symbol}`;
-    var data = await fetch(bestVarURL)
+    var data = fetch(bestVarURL)
         .then((response) => response.json())
+        .then((resp) => resp.data)
         .catch(failureCallback);
-    return data.data;
+    return data;
 }
 
 
 // Define a function that returns the search query type to the parseSearch function
 // We expect queries in the form of a single variant (chr:pos or rsnum), a range (chr:start-end), or a gene name (ENSG or symbol)
-async function parseSearchText(searchText) {
+function parseSearchText(searchText) {
     // Use regular expressions to match known patterns for single variant, range, and rs number
     const chromposPattern = /(chr)?([1-9][0-9]?|X|Y|MT):([1-9][0-9]+)/;
     const rangePattern = /(chr)?([1-9][0-9]?|X|Y|MT):([1-9][0-9]+)-([1-9][0-9]+)/;

--- a/pheget/static/js/searchbox.js
+++ b/pheget/static/js/searchbox.js
@@ -55,13 +55,13 @@ function parseSearchText(searchText) {
     if (cMatch !== null && searchText === cMatch[0]) {
         const chrom = cMatch[2];
         const pos = cMatch[3];
-        return {'type': 'variant', 'chrom': `${chrom}`, 'start': `${pos}`, 'end': `${pos}`};
+        return {'type': 'variant', 'chrom': {chrom}, 'start': {pos}, 'end': {pos}};
     } else if (cMatchRange !== null && searchText === cMatchRange[0]) {
         // If the query is a range in the form [chr]:[start]-[end], return the position of the range
         const chrom = cMatchRange[2];
         const start = cMatchRange[3];
         const end = cMatchRange[4];
-        return {type: 'range', chrom: `${chrom}`, start: `${start}`, end: `${end}`};
+        return {type: 'range', chrom: {chrom}, start: {start}, end: {end}};
     } else if (cMatchRS !== null && searchText === cMatchRS[0]) {
         // If input is in rs# format, use omnisearch to convert to chrom:pos, then return the position
         var returnType = getOmniSearch(searchText)
@@ -70,7 +70,7 @@ function parseSearchText(searchText) {
                 const chrom = varData.chrom;
                 const start = varData.start;
                 const end = varData.end;
-                var returnStatus = {type: 'variant', chrom: `${chrom}`, start: `${start}`, end: `${end}`};
+                var returnStatus = {type: 'variant', chrom: {chrom}, start: {start}, end: {end}};
                 return returnStatus;
             })
             .catch(failureCallback);

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,4 +3,4 @@
 fourmat==0.4.0
 pre-commit==1.20.0
 mypy==0.740
-pytest-flask==0.15.0
+pytest-flask==0.15.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,31 @@ def test_loads_region(client):
     assert client.get(url).status_code == 200
 
 
+def test_loads_region_bestvar(client):
+    # TODO: Ideally, we'd test this endpoint in a region where specifying `gene_id` changed the best result
+    url = url_for("api.region_query_bestvar", chrom="19", start=1, end=960996)
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.get_json()
+    assert content["data"]["tissue"] == "Thyroid"
+
+
+def test_loads_region_bestvar_for_gene(client):
+    """What is an example of the gene id altering the query for best variant in a region?"""
+    url = url_for(
+        "api.region_query_bestvar",
+        chrom="19",
+        start=1,
+        end=960996,
+        gene_id="ENSG00000129946.10",
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    content = response.get_json()
+    assert content["data"]["tissue"] == "Thyroid"
+
+
 def test_loads_variant(client):
     url = url_for("api.variant_query", chrom="19", pos=6718376)
     assert client.get(url).status_code == 200


### PR DESCRIPTION
## Ticket
Partly addresses #43

## Purpose
Add an API to return the best variant given a gene (symbol or gene_id), and rewrite/cleanup searchbox.js using Fetch API

## How to test this
Type different queries into the searchbox (chr:pos, chr:start-end, rsnum, gene_name, garbage input which should fail), and verify that the script is sending you to a page that makes sense:
- chr:pos -> single variant as requested
- chr:start-end -> range as requested
- rsnum -> single variant as requested
- gene_name -> **region view (with padding on both sides) for the tissue with the most significant eQTL** (updated)
- garbage input -> window alert of failure)

## Deployment / configuration notes
(none)
