### PR TITLE
Allow variant options to change the URL

### DIFF
--- a/pheget/frontend/templates/frontend/variant.html
+++ b/pheget/frontend/templates/frontend/variant.html
@@ -372,19 +372,25 @@
       // On hitting toggle buttons, run JavaScript to update plot views
       document.forms['grouping-buttons'].elements['group-options'].forEach(function (form) {
           form.onchange = function () {
-              groupByThing(plot, this.value);
+              groupByThing(plot.layout, this.value);
+              // Clear "same match" highlighting when re-rendering.
+              plot.applyState({ lz_match_value: null });
           };
       });
 
       document.forms['transform-y'].elements['y-options'].forEach(function (form) {
           form.onchange = function () {
-              switchY(plot, table, this.value);
+              const y_field = this.value;
+              switchY_Plot(plot, y_field);
+              switchY_Table(table, y_field);
+              plot.applyState({ y_field });
           };
       });
 
       document.forms['toggle-labels'].elements['label-options'].forEach(function (form) {
           form.onchange = function () {
-              labelTopVariants(plot, this.value);
+              labelTopVariants(plot.layout, this.value);
+              plot.applyState();
           };
       });
 


### PR DESCRIPTION
## Ticket
#35 

## Purpose
We would like users to be able to share a particular view. This PR demonstrates a proof of concept using the `DynamicURLs` extension with the variant page.

### TODO
- [x] Update the region page as well. This may require additional changes to LZ.js to support "array" query params (`panel[]=first&panel[]=second`); dynamic urls currently doesn't try to serialize those
- [x] Radio buttons should update to reflect options- currently, the plot reflects the URL, but surrounding widgets are not synchronized
  - [x] Coordinating this manually would not be fun. A full refactor to a proper dynamic UI like vue would help a lot but not be a trivially small task (we'd need to convert existing widgets like the search box etc)
- [ ] Style improvements
- [ ] Performance tweaks

## How to test this
(to be written)

## Deployment / configuration notes
(none)
