### PR TITLE
Converted some tooltips to popovers, and fixes to PIP display

### DIFF
--- a/src/assets/common.css
+++ b/src/assets/common.css
@@ -89,3 +89,7 @@ dl.variant-info-middle dd {
 .searchbox {
     width: 600px;
 }
+
+.nobreak {
+    white-space: nowrap;
+}

--- a/src/lz-helpers.js
+++ b/src/lz-helpers.js
@@ -27,6 +27,11 @@ function retrieveBySuffix(point_data, field_suffix) {
 LocusZoom.TransformationFunctions.set('pip_yvalue', (x) => Math.max(Math.log10(x), -4));
 
 /**
+ * Convert displayed pip, spip, or pip_cluster to missing '-' if value is 0
+ */
+LocusZoom.TransformationFunctions.set('pip_display', (x) => (x ? x.toString() : '-'));
+
+/**
  * Assign point shape based on PIP cluster designation. Since there are always just a few clusters, and cluster 1
  *  is most significant, this hard-coding is a workable approach.
  */

--- a/src/util/region-helpers.js
+++ b/src/util/region-helpers.js
@@ -37,9 +37,9 @@ export function getTrackLayout(gene_id, tissue, state, genesymbol) {
   }<strong>Gene</strong>: <i>{{{{namespace[assoc]}}symbol}}</i> <br>
         <strong>MAF</strong>: {{{{namespace[assoc]}}maf}} <br>
         <strong>NES</strong>: {{{{namespace[assoc]}}beta}} <br>
-        <strong>PIP</strong>: {{{{namespace[assoc]}}pip}} <br>
-        <strong>SPIP</strong>: {{{{namespace[assoc]}}spip}} <br>
-        <strong>PIP cluster</strong>: {{{{namespace[assoc]}}pip_cluster}} <br>
+        <strong>PIP</strong>: {{{{namespace[assoc]}}pip|pip_display}} <br>
+        <strong>SPIP</strong>: {{{{namespace[assoc]}}spip|pip_display}} <br>
+        <strong>PIP cluster</strong>: {{{{namespace[assoc]}}pip_cluster|pip_display}} <br>
         <a href='/variant/{{{{namespace[assoc]}}chromosome|urlencode}}_{{{{namespace[assoc]}}position|urlencode}}/'>Go to single-variant view</a>`;
 
   const namespace = { assoc: `assoc_${tissue}_${geneid_short}` };

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -138,9 +138,9 @@ export function getPlotLayout(chrom, pos, initialState = {}) {
 <strong>MAF:</strong> {{{{namespace[phewas]}}maf|twosigfigs|htmlescape}}<br>
 <strong>TSS distance:</strong> {{{{namespace[phewas]}}tss_distance|htmlescape}}<br>
 <strong>System:</strong> {{{{namespace[phewas]}}system|htmlescape}}<br>
-<strong>PIP:</strong> {{{{namespace[phewas]}}pip}}<br>
-<strong>SPIP:</strong> {{{{namespace[phewas]}}spip}}<br>
-<strong>PIP cluster:</strong> {{{{namespace[phewas]}}pip_cluster}}<br>
+<strong>PIP:</strong> {{{{namespace[phewas]}}pip|pip_display}}<br>
+<strong>SPIP:</strong> {{{{namespace[phewas]}}spip|pip_display}}<br>
+<strong>PIP cluster:</strong> {{{{namespace[phewas]}}pip_cluster|pip_display}}<br>
 <a href='/region/?position={{{{namespace[phewas]}}position|urlencode}}&chrom={{{{namespace[phewas]}}chromosome|urlencode}}&gene_id={{{{namespace[phewas]}}gene_id|urlencode}}&tissue={{{{namespace[phewas]}}tissue|urlencode}}'>See region plot for <i>{{{{namespace[phewas]}}symbol}}</i> x {{{{namespace[phewas]}}tissue}}</a>
 `;
               base.match = {
@@ -379,7 +379,7 @@ function two_digit_fmt2(cell) {
 function pip_fmt(cell) {
   const x = cell.getValue();
   if (x === 0) {
-    return '0';
+    return '-';
   }
   return x.toPrecision(2);
 }

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -330,23 +330,24 @@ export default {
 
         <b-dropdown text="Y-axis" class="m-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right.html
-                   title="Display -log<sub>10</sub>(P-values) on the Y-axis">
+            <label>
               <input type="radio" name="y-options" id="show-log-pvalue"
                      v-model="y_field" value="log_pvalue"> -log<sub>10</sub> P
             </label>
-
-            <label v-b-tooltip.right.html
-                   title="Displays Normalized Effect Sizes (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
+            <label>
               <input type="radio" name="y-options" id="show-beta"
-                     v-model="y_field" value="beta"> Effect size
+                     v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span>
             </label>
-
-            <label v-b-tooltip.right.html
-                   title="Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.">
+            <b-popover target="y-axis-radio-effectsize">
+              Displays Normalized Effect Sizes (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.
+            </b-popover>
+            <label>
               <input type="radio" name="y-options" id="show-pip"
-                     v-model="y_field" value="pip"> PIP
+                     v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span>
             </label>
+            <b-popover target="y-axis-radio-pip">
+              Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.
+            </b-popover>
           </b-dropdown-text>
         </b-dropdown>
       </div>

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -335,15 +335,15 @@ export default {
                      v-model="y_field" value="log_pvalue"> -log<sub>10</sub> P
             </label>
             <label>
-              <input type="radio" name="y-options" id="show-beta"
-                     v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="y-options" id="show-beta"
+                     v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span></span>
             </label>
             <b-popover target="y-axis-radio-effectsize">
               Displays Normalized Effect Sizes (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.
             </b-popover>
             <label>
-              <input type="radio" name="y-options" id="show-pip"
-                     v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="y-options" id="show-pip"
+                     v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span></span>
             </label>
             <b-popover target="y-axis-radio-pip">
               Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -292,22 +292,22 @@ export default {
         <b-dropdown text="X-Axis Group" class="mr-2" size="sm">
           <b-dropdown-text>
             <label>
-              <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="tissue"> Tissue <span id="x-axis-radio-tissue" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="group-options" autocomplete="off"
+                    v-model="group" value="tissue"> Tissue <span id="x-axis-radio-tissue" class="fa fa-info-circle"></span></span>
               <b-popover target="x-axis-radio-tissue">
                 Group eQTLs by tissues, sorted alphabetically
               </b-popover>
             </label>
             <label>
-              <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="system"> System <span id="x-axis-radio-system" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="group-options" autocomplete="off"
+                    v-model="group" value="system"> System <span id="x-axis-radio-system" class="fa fa-info-circle"></span></span>
               <b-popover target="x-axis-radio-system">
                 Group eQTLs by systems as defined by the GTEx project, sorted alphabetically
               </b-popover>
             </label>
             <label>
-              <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="symbol"> Gene <span id="x-axis-radio-gene" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="group-options" autocomplete="off"
+                    v-model="group" value="symbol"> Gene <span id="x-axis-radio-gene" class="fa fa-info-circle"></span></span>
               <b-popover target="x-axis-radio-gene">
                 Group eQTLs by gene, sorted by the position of the genes' transcription start sites
               </b-popover>
@@ -321,13 +321,13 @@ export default {
               <input type="radio" name="y-options" v-model="y_field" value="log_pvalue"> -log<sub>10</sub> P
             </label>
             <label>
-              <input type="radio" name="y-options" v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="y-options" v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span></span>
               <b-popover target="y-axis-radio-effectsize">
                 Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage' target='_blank'>the GTEx Portal</a> for an explanation of NES.
               </b-popover>
             </label>
             <label>
-              <input type="radio" name="y-options" v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="y-options" v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span></span>
               <b-popover target="y-axis-radio-pip">
                 Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.
               </b-popover>
@@ -338,19 +338,19 @@ export default {
         <b-dropdown text="Labels" class="mr-2" size="sm">
           <b-dropdown-text>
             <label>
-              <input type="radio" name="label-options" v-model="n_labels" :value="0"> No labels <span id="labels-radio-none" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="0"> No labels <span id="labels-radio-none" class="fa fa-info-circle"></span></span>
               <b-popover target="labels-radio-none">
                Turn off all labels
                </b-popover>
             </label>
             <label>
-              <input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5 <span id="labels-radio-5" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5 <span id="labels-radio-5" class="fa fa-info-circle"></span></span>
               <b-popover target="labels-radio-5">
                 If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
               </b-popover>
             </label>
             <label>
-              <input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20 <span id="labels-radio-20" class="fa fa-info-circle"></span>
+              <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20 <span id="labels-radio-20" class="fa fa-info-circle"></span></span>
               <b-popover target="labels-radio-20">
                 If viewing P-values, add labels to the 20 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
               </b-popover>

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -291,54 +291,69 @@ export default {
       <div class="col-sm-12">
         <b-dropdown text="X-Axis Group" class="mr-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right
-                  title="Group eQTLs by tissues, sorted alphabetically">
+            <label>
               <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="tissue"> Tissue
+                    v-model="group" value="tissue"> Tissue <span id="x-axis-radio-tissue" class="fa fa-info-circle"></span>
+              <b-popover target="x-axis-radio-tissue">
+                Group eQTLs by tissues, sorted alphabetically
+              </b-popover>
             </label>
-            <label v-b-tooltip.right
-                  title="Group eQTLs by systems as defined by the GTEx project, sorted alphabetically">
+            <label>
               <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="system"> System
+                    v-model="group" value="system"> System <span id="x-axis-radio-system" class="fa fa-info-circle"></span>
+              <b-popover target="x-axis-radio-system">
+                Group eQTLs by systems as defined by the GTEx project, sorted alphabetically
+              </b-popover>
             </label>
-            <label v-b-tooltip.right
-                  title="Group eQTLs by gene, sorted by the position of the genes' transcription start sites">
+            <label>
               <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="symbol"> Gene
+                    v-model="group" value="symbol"> Gene <span id="x-axis-radio-gene" class="fa fa-info-circle"></span>
+              <b-popover target="x-axis-radio-gene">
+                Group eQTLs by gene, sorted by the position of the genes' transcription start sites
+              </b-popover>
             </label>
           </b-dropdown-text>
         </b-dropdown>
 
         <b-dropdown text="Y-Axis" class="mr-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right.html
-                  title="Display -log<sub>10</sub>(P-values) on the Y-axis">
+            <label>
               <input type="radio" name="y-options" v-model="y_field" value="log_pvalue"> -log<sub>10</sub> P
             </label>
-            <label v-b-tooltip.right.html
-                  title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage' target='_blank'>the GTEx Portal</a> for an explanation of NES.">
-              <input type="radio" name="y-options" v-model="y_field" value="beta"> Effect size
+            <label>
+              <input type="radio" name="y-options" v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span>
+              <b-popover target="y-axis-radio-effectsize">
+                Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage' target='_blank'>the GTEx Portal</a> for an explanation of NES.
+              </b-popover>
             </label>
-            <label v-b-tooltip.right.html
-                  title="Displays <a href='https://doi.org/10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.">
-              <input type="radio" name="y-options" v-model="y_field" value="pip"> PIP
+            <label>
+              <input type="radio" name="y-options" v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span>
+              <b-popover target="y-axis-radio-pip">
+                Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.
+              </b-popover>
             </label>
           </b-dropdown-text>
         </b-dropdown>
 
         <b-dropdown text="Labels" class="mr-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right
-                  title="Turn off all labels">
-              <input type="radio" name="label-options" v-model="n_labels" :value="0"> No labels
+            <label>
+              <input type="radio" name="label-options" v-model="n_labels" :value="0"> No labels <span id="labels-radio-none" class="fa fa-info-circle"></span>
+              <b-popover target="labels-radio-none">
+               Turn off all labels
+               </b-popover>
             </label>
-            <label v-b-tooltip.right.html
-                  title="If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
-              <input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5
+            <label>
+              <input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5 <span id="labels-radio-5" class="fa fa-info-circle"></span>
+              <b-popover target="labels-radio-5">
+                If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
+              </b-popover>
             </label>
-            <label v-b-tooltip.right.html
-                  title="If viewing P-values, add labels to the 20 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
-              <input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20
+            <label>
+              <input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20 <span id="labels-radio-20" class="fa fa-info-circle"></span>
+              <b-popover target="labels-radio-20">
+                If viewing P-values, add labels to the 20 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
+              </b-popover>
             </label>
           </b-dropdown-text>
         </b-dropdown>


### PR DESCRIPTION
## Ticket
n/a

## Purpose
- Converted many tooltips to popovers so they won't get in your way when you are trying to click buttons.
- Changed PIP displays of 0 to '-'. This applies to PIP, SPIP, and PIP_cluster.
- Removed explanations for Log10 P-values.
- Did not fix bug where clicking on a link in a popover fails to open the link.

## How to test this
- Click on popover tooltips to make sure they show up correctly
- Look at PIP values in plots and tables to check if the missing values are displayed correctly as '-'.

## Deployment / configuration notes
(none)
