### PR TITLE
Feature/region view pip table

### DIFF
--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -155,7 +155,6 @@ def region_query_toppip(chrom: str, start: int, end: int):
     for i in range(1, 11):
         top10keylist.append("Tissue:Gene:" + str(i))
         top10piplist.append(float(i) * 1e-6)
-        # top10datalist.append([])
     minPip = 1e-6
     minPipIdx = 0
     for datapoint in data:
@@ -183,4 +182,7 @@ def region_query_toppip(chrom: str, start: int, end: int):
             top10datalist[minPipIdx] = datapoint
             minPip = min(top10piplist)
             minPipIdx = top10piplist.index(minPip)
+    for i in range(9, -1, -1):  # Get rid of empty results
+        if top10datalist[i] == []:
+            top10datalist.pop(i)
     return jsonify(top10datalist)

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -24,11 +24,17 @@ def region_query(chrom, start, end):
     """
     tissue = request.args.get("tissue", None)
     gene_id = request.args.get("gene_id", None)
+    piponly = request.args.get("piponly", None)
 
     data = [
         res.to_dict()
         for res in query_variants(
-            chrom=chrom, start=start, end=end, tissue=tissue, gene_id=gene_id
+            chrom=chrom,
+            start=start,
+            end=end,
+            tissue=tissue,
+            gene_id=gene_id,
+            piponly=piponly,
         )
     ]
 

--- a/pheget/api/__init__.py
+++ b/pheget/api/__init__.py
@@ -129,24 +129,3 @@ def variant_query(chrom: str, pos: int):
 
     results = {"data": data}
     return jsonify(results)
-
-
-@api_blueprint.route(
-    "/region/<string:chrom>/<int:start>-<int:end>/data/", methods=["GET"]
-)
-def region_query_dataonly(chrom: str, start: int, end: int):
-    """
-    Given a region and optionally a gene_id,
-    return all eQTLs, optionally only for points with non-zero PIP values
-    """
-    gene_id = request.args.get("gene_id", None)
-    piponly = request.args.get("piponly", False)
-    if chrom is not None and chrom[0:3] == "chr":
-        chrom = chrom[3:]
-    data = [
-        res.to_dict()
-        for res in query_variants(
-            chrom, start, end=end, gene_id=gene_id, piponly=piponly
-        )
-    ]
-    return jsonify(data)

--- a/pheget/api/format.py
+++ b/pheget/api/format.py
@@ -278,6 +278,7 @@ def query_variants(
     end: int = None,
     tissue: str = None,
     gene_id: str = None,
+    piponly: bool = False,
 ) -> ty.Iterable[VariantContainer]:
     """
     Fetch GTEx data for one or more variants, and apply optional filters
@@ -327,6 +328,10 @@ def query_variants(
 
     reader.add_filter("maf")
     reader.add_filter(lambda result: result.maf > 0.0)
+
+    if piponly:
+        reader.add_filter("pip")
+        reader.add_filter(lambda result: result.pip > 0.0)
 
     if end is None:
         # Single variant query

--- a/pheget/api/format.py
+++ b/pheget/api/format.py
@@ -329,6 +329,8 @@ def query_variants(
     reader.add_filter("maf")
     reader.add_filter(lambda result: result.maf > 0.0)
 
+    # PIP === 0.0 only if the data point is missing in the DAP-G database.
+    # Using this filter returns only points which are found in the DAP-G database.
     if piponly:
         reader.add_filter("pip")
         reader.add_filter(lambda result: result.pip > 0.0)

--- a/src/assets/common.css
+++ b/src/assets/common.css
@@ -89,3 +89,7 @@ dl.variant-info-middle dd {
 .searchbox {
     width: 600px;
 }
+
+.nobreak {
+    white-space: nowrap;
+}

--- a/src/components/TabulatorTable.vue
+++ b/src/components/TabulatorTable.vue
@@ -8,7 +8,8 @@ import 'tabulator-tables/dist/css/bootstrap/tabulator_bootstrap4.min.css';
 export default {
   name: 'TabulatorTable',
   props: {
-    table_data: Array,
+    ajaxURL: null,
+    table_data: { default() { return []; }, type: Array },
     columns: Array,
     sort: Array,
     layout: { default: 'fitData' },
@@ -64,9 +65,14 @@ export default {
       },
       deep: true,
     },
+    ajaxUrl(value) {
+      // Force reload of data when url changes
+      this.tabulator.setData(value);
+    },
   },
   mounted() {
     const {
+      ajaxURL,
       table_data: data,
       columns,
       height,
@@ -89,6 +95,7 @@ export default {
     this.tabulator = new Tabulator(
       this.$refs.table,
       {
+        ajaxURL,
         data,
         columns,
         height,

--- a/src/components/TabulatorTable.vue
+++ b/src/components/TabulatorTable.vue
@@ -108,6 +108,9 @@ export default {
         tooltips,
         tooltipGenerationMode,
         tooltipsHeader,
+        ajaxResponse(url, params, response) {
+          return response.data;
+        },
       },
     );
     // Expose a reference to the raw table object, for advanced usages such as click events

--- a/src/lz-helpers.js
+++ b/src/lz-helpers.js
@@ -27,6 +27,11 @@ function retrieveBySuffix(point_data, field_suffix) {
 LocusZoom.TransformationFunctions.set('pip_yvalue', (x) => Math.max(Math.log10(x), -4));
 
 /**
+ * Convert displayed pip, spip, or pip_cluster to missing '-' if value is 0
+ */
+LocusZoom.TransformationFunctions.set('pip_display', (x) => (x ? x.toString() : '-'));
+
+/**
  * Assign point shape based on PIP cluster designation. Since there are always just a few clusters, and cluster 1
  *  is most significant, this hard-coding is a workable approach.
  */

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -13,5 +13,28 @@ function handleErrors(response) {
   return response;
 }
 
+/**
+ * Remove the `sourcename:` prefix from field names in the data returned by an LZ datasource
+ *
+ * This is a convenience method for writing external widgets (like tables) that subscribe to the
+ *   plot; typically we don't want to have to redefine the table layout every time someone selects
+ *   a different association study.
+ * As with all convenience methods, it has limits: don't use it if the same field name is requested
+ *   from two different sources!
+ * @param {Object} data An object representing the fields for one row of data
+ * @param {String} [prefer] Sometimes, two sources provide a field with same name. Specify which
+ *  source will take precedence in the event of a conflict.
+ */
+export function deNamespace(data, prefer) {
+  return Object.keys(data).reduce((acc, key) => {
+    const new_key = key.replace(/.*?:/, '');
+    if (!Object.prototype.hasOwnProperty.call(acc, new_key)
+        || (!prefer || key.startsWith(prefer))) {
+      acc[new_key] = data[key];
+    }
+    return acc;
+  }, {});
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export { handleErrors, PORTALDEV_URL };

--- a/src/util/region-helpers.js
+++ b/src/util/region-helpers.js
@@ -37,9 +37,9 @@ export function getTrackLayout(gene_id, tissue, state, genesymbol) {
   }<strong>Gene</strong>: <i>{{{{namespace[assoc]}}symbol}}</i> <br>
         <strong>MAF</strong>: {{{{namespace[assoc]}}maf}} <br>
         <strong>NES</strong>: {{{{namespace[assoc]}}beta}} <br>
-        <strong>PIP</strong>: {{{{namespace[assoc]}}pip}} <br>
-        <strong>SPIP</strong>: {{{{namespace[assoc]}}spip}} <br>
-        <strong>PIP cluster</strong>: {{{{namespace[assoc]}}pip_cluster}} <br>
+        <strong>PIP</strong>: {{{{namespace[assoc]}}pip|pip_display}} <br>
+        <strong>SPIP</strong>: {{{{namespace[assoc]}}spip|pip_display}} <br>
+        <strong>PIP cluster</strong>: {{{{namespace[assoc]}}pip_cluster|pip_display}} <br>
         <a href='/variant/{{{{namespace[assoc]}}chromosome|urlencode}}_{{{{namespace[assoc]}}position|urlencode}}/'>Go to single-variant view</a>`;
 
   const namespace = { assoc: `assoc_${tissue}_${geneid_short}` };

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -379,10 +379,19 @@ function two_digit_fmt2(cell) {
 function pip_fmt(cell) {
   const x = cell.getValue();
   if (x === 0) {
-    return '0';
+    return '-';
   }
   return x.toPrecision(2);
 }
+
+function pip_cluster_fmt(cell) {
+  const x = cell.getValue();
+  if (x === 0) {
+    return '-';
+  }
+  return x.toFixed(0);
+}
+
 
 export function tabulator_tooltip_maker(cell) {
   // Only show tooltips when an ellipsis ('...') is hiding part of the data.
@@ -416,4 +425,5 @@ export const TABLE_BASE_COLUMNS = [
   { title: 'Effect Size', field: 'beta', formatter: two_digit_fmt1, sorter: 'number' },
   { title: 'SE (Effect Size)', field: 'stderr_beta', formatter: two_digit_fmt1 },
   { title: 'PIP', field: 'pip', formatter: pip_fmt },
+  { title: 'PIP cluster', field: 'pip_cluster', formatter: pip_cluster_fmt },
 ];

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -138,9 +138,9 @@ export function getPlotLayout(chrom, pos, initialState = {}) {
 <strong>MAF:</strong> {{{{namespace[phewas]}}maf|twosigfigs|htmlescape}}<br>
 <strong>TSS distance:</strong> {{{{namespace[phewas]}}tss_distance|htmlescape}}<br>
 <strong>System:</strong> {{{{namespace[phewas]}}system|htmlescape}}<br>
-<strong>PIP:</strong> {{{{namespace[phewas]}}pip}}<br>
-<strong>SPIP:</strong> {{{{namespace[phewas]}}spip}}<br>
-<strong>PIP cluster:</strong> {{{{namespace[phewas]}}pip_cluster}}<br>
+<strong>PIP:</strong> {{{{namespace[phewas]}}pip|pip_display}}<br>
+<strong>SPIP:</strong> {{{{namespace[phewas]}}spip|pip_display}}<br>
+<strong>PIP cluster:</strong> {{{{namespace[phewas]}}pip_cluster|pip_display}}<br>
 <a href='/region/?position={{{{namespace[phewas]}}position|urlencode}}&chrom={{{{namespace[phewas]}}chromosome|urlencode}}&gene_id={{{{namespace[phewas]}}gene_id|urlencode}}&tissue={{{{namespace[phewas]}}tissue|urlencode}}'>See region plot for <i>{{{{namespace[phewas]}}symbol}}</i> x {{{{namespace[phewas]}}tissue}}</a>
 `;
               base.match = {

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -399,21 +399,21 @@ export function tabulator_tooltip_maker(cell) {
 export const TABLE_BASE_COLUMNS = [
   {
     title: 'Gene',
-    field: 'phewas:symbol',
+    field: 'symbol',
     headerFilter: true,
     formatter(cell) {
-      return `<i>${cell.getValue()} (${cell.getData()['phewas:gene_id']}</i>)`;
+      return `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`;
     },
   },
-  { title: 'Tissue', field: 'phewas:tissue', headerFilter: true },
-  { title: 'System', field: 'phewas:system', headerFilter: true },
+  { title: 'Tissue', field: 'tissue', headerFilter: true },
+  { title: 'System', field: 'system', headerFilter: true },
   {
     title: '-log<sub>10</sub>(p)',
-    field: 'phewas:log_pvalue',
+    field: 'log_pvalue',
     formatter: two_digit_fmt2,
     sorter: 'number',
   },
-  { title: 'Effect Size', field: 'phewas:beta', formatter: two_digit_fmt1, sorter: 'number' },
-  { title: 'SE (Effect Size)', field: 'phewas:stderr_beta', formatter: two_digit_fmt1 },
-  { title: 'PIP', field: 'phewas:pip', formatter: pip_fmt },
+  { title: 'Effect Size', field: 'beta', formatter: two_digit_fmt1, sorter: 'number' },
+  { title: 'SE (Effect Size)', field: 'stderr_beta', formatter: two_digit_fmt1 },
+  { title: 'PIP', field: 'pip', formatter: pip_fmt },
 ];

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -96,7 +96,7 @@ export default {
       // Update how tabulator is drawn, whenever y_field changes
       return [{ column: `phewas:${this.y_field}`, dir: 'desc' }];
     },
-    ajax_url() {
+    top_hits_url() {
       // Re-calculate API URL when chrom, start, and/or end changes.
       const { chrom, start, end } = this;
       return `/api/data/region/${chrom}/${start}-${end}/top10pip/`;
@@ -450,7 +450,7 @@ export default {
     <div ref="eqtl-table" class="padtop">
       <h2>Top PIP clusters</h2>
       <tabulator-table :columns="table_base_columns"
-                       :table_data="table_data"
+                       :ajaxURL="top_hits_url"
                        :sort="table_sort"
                        :tooltips="tabulator_tooltip_maker"
                        tooltip-generation-mode="hover"

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -397,7 +397,7 @@ export default {
         <div class="card">
           <div class="card-body">
             External links:
-            <a :href="`http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr${ chrom }%3A${ start }-${ end }`"
+            <a :href="`http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr${ chrom }%3A${ start }-${ end }&highlight=hg38.chr${ chrom }%3A${ start }-${ end }`"
                 target="_blank" class="btn btn-secondary btn-sm mr-1" role="button" aria-pressed="true"
                 v-b-tooltip.top
                 title="The UC Santa Cruz Genome Browser"> UCSC <span

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -96,6 +96,11 @@ export default {
       // Update how tabulator is drawn, whenever y_field changes
       return [{ column: `phewas:${this.y_field}`, dir: 'desc' }];
     },
+    ajax_url() {
+      // Re-calculate API URL when chrom, start, and/or end changes.
+      const { chrom, start, end } = this;
+      return `/api/data/region/${chrom}/${start}-${end}/top10pip/`;
+    },
   },
   beforeCreate() {
     // See: https://router.vuejs.org/guide/advanced/data-fetching.html#fetching-before-navigation

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -33,12 +33,6 @@ function getData(queryParams) {
     .then((resp) => resp.json());
 }
 
-// function getTopPipData(chrom, start, end) {
-//   return fetch(`/api/data/region/${chrom}/${start}-${end}/top10pip/`)
-//     .then(handleErrors)
-//     .then((resp) => resp.json());
-// }
-
 export default {
   name: 'RegionView',
   data() {

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -6,6 +6,7 @@ import { handleErrors } from '@/util/common';
 import LzPlot from '@/components/LzPlot.vue';
 import SearchBox from '@/components/SearchBox.vue';
 import SelectAnchors from '@/components/SelectAnchors.vue';
+import TabulatorTable from '@/components/TabulatorTable.vue';
 
 import {
   addTrack,
@@ -15,6 +16,11 @@ import {
   getTrackSources,
   switchY_region,
 } from '@/util/region-helpers';
+
+import {
+  TABLE_BASE_COLUMNS,
+  tabulator_tooltip_maker,
+} from '@/util/variant-helpers';
 
 /**
  * Get the data required to render the template
@@ -29,6 +35,12 @@ function getData(queryParams) {
     .then(handleErrors)
     .then((resp) => resp.json());
 }
+
+// function getTopPipData(chrom, start, end) {
+//   return fetch(`/api/data/region/${chrom}/${start}-${end}/top10pip/`)
+//     .then(handleErrors)
+//     .then((resp) => resp.json());
+// }
 
 export default {
   name: 'RegionView',
@@ -49,6 +61,9 @@ export default {
 
       extra_genes: [],
       extra_tissues: [],
+
+      // Internal data passed between widgets
+      table_data: [],
 
       // Internal state
       base_plot_sources: null,
@@ -77,6 +92,10 @@ export default {
       }
       return $.param(options);
     },
+    table_sort() {
+      // Update how tabulator is drawn, whenever y_field changes
+      return [{ column: `phewas:${this.y_field}`, dir: 'desc' }];
+    },
   },
   beforeCreate() {
     // See: https://router.vuejs.org/guide/advanced/data-fetching.html#fetching-before-navigation
@@ -86,6 +105,10 @@ export default {
     //  observables.
     this.assoc_plot = null;
     this.assoc_sources = null;
+
+    // Make some constants available to the Vue instance for use as props in rendering
+    this.table_base_columns = TABLE_BASE_COLUMNS;
+    this.tabulator_tooltip_maker = tabulator_tooltip_maker;
   },
   beforeRouteEnter(to, from, next) {
     // Fires on first navigation to route (from another route)
@@ -247,6 +270,7 @@ export default {
     LzPlot,
     SearchBox,
     SelectAnchors,
+    TabulatorTable,
   },
 };
 </script>
@@ -417,6 +441,15 @@ export default {
           </div>
         </div>
       </div>
+    </div>
+    <div ref="eqtl-table" class="padtop">
+      <h2>Top PIP clusters</h2>
+      <tabulator-table :columns="table_base_columns"
+                       :table_data="table_data"
+                       :sort="table_sort"
+                       :tooltips="tabulator_tooltip_maker"
+                       tooltip-generation-mode="hover"
+                       :tooltips-header="true" />
     </div>
   </div>
 </template>

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -89,6 +89,8 @@ export default {
     },
     range_data_url() {
       // Re-calculate URL to retrieve all variants when chrom, start, and/or end changes.
+      // Add the option "?piponly=True" to the end of the url to return only points
+      // with non-missing PIP values, i.e. only points that are found in the DAP-G database
       const { chrom, start, end } = this;
       return `/api/data/region/${chrom}/${start}-${end}/`;
     },

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -93,10 +93,10 @@ export default {
       // Update how tabulator is drawn, whenever y_field changes
       return [{ column: this.y_field, dir: 'desc' }];
     },
-    top_hits_url() {
-      // Re-calculate API URL when chrom, start, and/or end changes.
+    range_data_url() {
+      // Re-calculate URL to retrieve all variants when chrom, start, and/or end changes.
       const { chrom, start, end } = this;
-      return `/api/data/region/${chrom}/${start}-${end}/top10pip/`;
+      return `/api/data/region/${chrom}/${start}-${end}/data/`;
     },
   },
   beforeCreate() {
@@ -291,6 +291,7 @@ export default {
         <h6 class="mr-2">Jump to:</h6>
         <b-button @click="goto('region-plot')" class="mr-2 btn-light btn-link" size="sm">Plot <span class="fas fa-level-down-alt"></span></b-button>
         <b-button @click="goto('external-links')" class="mr-2 btn-light btn-link" size="sm">External links <span class="fas fa-level-down-alt"></span></b-button>
+        <b-button @click="goto('eqtl-table')" class="mr-2 btn-light btn-link" size="sm">eQTL Table <span class="fas fa-level-down-alt"></span></b-button>
         <b-navbar-nav class="ml-auto">
           <search-box class="searchbox"/>
         </b-navbar-nav>
@@ -391,7 +392,7 @@ export default {
     </div>
 
     <div class="row">
-      <div class="col-sm-12" ref="external-links">
+      <div class="col-sm-12 padtop" ref="external-links">
         <div class="card">
           <div class="card-body">
             External links:
@@ -445,9 +446,9 @@ export default {
       </div>
     </div>
     <div ref="eqtl-table" class="padtop">
-      <h2>Top PIP clusters</h2>
+      <h2>eQTLs in region</h2>
       <tabulator-table :columns="table_base_columns"
-                       :ajaxURL="top_hits_url"
+                       :ajaxURL="range_data_url"
                        :sort="table_sort"
                        :tooltips="tabulator_tooltip_maker"
                        tooltip-generation-mode="hover"

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -17,10 +17,7 @@ import {
   switchY_region,
 } from '@/util/region-helpers';
 
-import {
-  TABLE_BASE_COLUMNS,
-  tabulator_tooltip_maker,
-} from '@/util/variant-helpers';
+import { TABLE_BASE_COLUMNS, tabulator_tooltip_maker } from '@/util/variant-helpers';
 
 /**
  * Get the data required to render the template
@@ -94,7 +91,7 @@ export default {
     },
     table_sort() {
       // Update how tabulator is drawn, whenever y_field changes
-      return [{ column: `phewas:${this.y_field}`, dir: 'desc' }];
+      return [{ column: this.y_field, dir: 'desc' }];
     },
     top_hits_url() {
       // Re-calculate API URL when chrom, start, and/or end changes.

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -90,7 +90,7 @@ export default {
     range_data_url() {
       // Re-calculate URL to retrieve all variants when chrom, start, and/or end changes.
       const { chrom, start, end } = this;
-      return `/api/data/region/${chrom}/${start}-${end}/data/`;
+      return `/api/data/region/${chrom}/${start}-${end}/`;
     },
   },
   beforeCreate() {

--- a/src/views/Region.vue
+++ b/src/views/Region.vue
@@ -357,23 +357,24 @@ export default {
 
         <b-dropdown text="Y-axis" class="m-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right.html
-                   title="Display -log<sub>10</sub>(P-values) on the Y-axis">
+            <label>
               <input type="radio" name="y-options" id="show-log-pvalue"
                      v-model="y_field" value="log_pvalue"> -log<sub>10</sub> P
             </label>
-
-            <label v-b-tooltip.right.html
-                   title="Displays Normalized Effect Sizes (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.">
-              <input type="radio" name="y-options" id="show-beta"
-                     v-model="y_field" value="beta"> Effect size
+            <label>
+              <span class=nobreak><input type="radio" name="y-options" id="show-beta"
+                     v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span></span>
             </label>
-
-            <label v-b-tooltip.right.html
-                   title="Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.">
-              <input type="radio" name="y-options" id="show-pip"
-                     v-model="y_field" value="pip"> PIP
+            <b-popover target="y-axis-radio-effectsize">
+              Displays Normalized Effect Sizes (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage'>the GTEx Portal</a> for an explanation of NES.
+            </b-popover>
+            <label>
+              <span class=nobreak><input type="radio" name="y-options" id="show-pip"
+                     v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span></span>
             </label>
+            <b-popover target="y-axis-radio-pip">
+              Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.
+            </b-popover>
           </b-dropdown-text>
         </b-dropdown>
       </div>

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -185,6 +185,7 @@ export default {
         [
           'phewas:log_pvalue', 'phewas:gene_id', 'phewas:tissue', 'phewas:system',
           'phewas:symbol', 'phewas:beta', 'phewas:stderr_beta', 'phewas:pip',
+          'phewas:pip_cluster',
         ],
         (data) => {
           // Data sent from locuszoom contains a prefix (phewas:). We'll remove that prefix before

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -297,54 +297,69 @@ export default {
       <div class="col-sm-12">
         <b-dropdown text="X-Axis Group" class="mr-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right
-                  title="Group eQTLs by tissues, sorted alphabetically">
-              <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="tissue"> Tissue
+            <label>
+              <span class=nobreak><input type="radio" name="group-options" autocomplete="off"
+                    v-model="group" value="tissue"> Tissue <span id="x-axis-radio-tissue" class="fa fa-info-circle"></span></span>
+              <b-popover target="x-axis-radio-tissue">
+                Group eQTLs by tissues, sorted alphabetically
+              </b-popover>
             </label>
-            <label v-b-tooltip.right
-                  title="Group eQTLs by systems as defined by the GTEx project, sorted alphabetically">
-              <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="system"> System
+            <label>
+              <span class=nobreak><input type="radio" name="group-options" autocomplete="off"
+                    v-model="group" value="system"> System <span id="x-axis-radio-system" class="fa fa-info-circle"></span></span>
+              <b-popover target="x-axis-radio-system">
+                Group eQTLs by systems as defined by the GTEx project, sorted alphabetically
+              </b-popover>
             </label>
-            <label v-b-tooltip.right
-                  title="Group eQTLs by gene, sorted by the position of the genes' transcription start sites">
-              <input type="radio" name="group-options" autocomplete="off"
-                    v-model="group" value="symbol"> Gene
+            <label>
+              <span class=nobreak><input type="radio" name="group-options" autocomplete="off"
+                    v-model="group" value="symbol"> Gene <span id="x-axis-radio-gene" class="fa fa-info-circle"></span></span>
+              <b-popover target="x-axis-radio-gene">
+                Group eQTLs by gene, sorted by the position of the genes' transcription start sites
+              </b-popover>
             </label>
           </b-dropdown-text>
         </b-dropdown>
 
         <b-dropdown text="Y-Axis" class="mr-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right.html
-                  title="Display -log<sub>10</sub>(P-values) on the Y-axis">
+            <label>
               <input type="radio" name="y-options" v-model="y_field" value="log_pvalue"> -log<sub>10</sub> P
             </label>
-            <label v-b-tooltip.right.html
-                  title="Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage' target='_blank'>the GTEx Portal</a> for an explanation of NES.">
-              <input type="radio" name="y-options" v-model="y_field" value="beta"> Effect size
+            <label>
+              <span class=nobreak><input type="radio" name="y-options" v-model="y_field" value="beta"> Effect size <span id="y-axis-radio-effectsize" class="fa fa-info-circle"></span></span>
+              <b-popover target="y-axis-radio-effectsize">
+                Displays Normalized Effect Size (NES) on the Y-axis. See <a href='https://www.gtexportal.org/home/documentationPage' target='_blank'>the GTEx Portal</a> for an explanation of NES.
+              </b-popover>
             </label>
-            <label v-b-tooltip.right.html
-                  title="Displays <a href='https://doi.org/10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.">
-              <input type="radio" name="y-options" v-model="y_field" value="pip"> PIP
+            <label>
+              <span class=nobreak><input type="radio" name="y-options" v-model="y_field" value="pip"> PIP <span id="y-axis-radio-pip" class="fa fa-info-circle"></span></span>
+              <b-popover target="y-axis-radio-pip">
+                Displays <a href='https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1006646' target='_blank'>DAP-G</a> Posterior Inclusion Probabilities (PIP) on the Y-axis.<br>Cluster 1 denotes the cluster of variants (in LD with each other) with the strongest signal; cluster 2 denotes the set of variants with the next strongest signal; and so on.
+              </b-popover>
             </label>
           </b-dropdown-text>
         </b-dropdown>
 
         <b-dropdown text="Labels" class="mr-2" size="sm">
           <b-dropdown-text>
-            <label v-b-tooltip.right
-                  title="Turn off all labels">
-              <input type="radio" name="label-options" v-model="n_labels" :value="0"> No labels
+            <label>
+              <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="0"> No labels <span id="labels-radio-none" class="fa fa-info-circle"></span></span>
+              <b-popover target="labels-radio-none">
+               Turn off all labels
+               </b-popover>
             </label>
-            <label v-b-tooltip.right.html
-                  title="If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
-              <input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5
+            <label>
+              <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5 <span id="labels-radio-5" class="fa fa-info-circle"></span></span>
+              <b-popover target="labels-radio-5">
+                If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
+              </b-popover>
             </label>
-            <label v-b-tooltip.right.html
-                  title="If viewing P-values, add labels to the 20 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.">
-              <input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20
+            <label>
+              <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20 <span id="labels-radio-20" class="fa fa-info-circle"></span></span>
+              <b-popover target="labels-radio-20">
+                If viewing P-values, add labels to the 20 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
+              </b-popover>
             </label>
           </b-dropdown-text>
         </b-dropdown>

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -4,7 +4,7 @@
  */
 import $ from 'jquery';
 import '@/lz-helpers';
-import { handleErrors } from '@/util/common';
+import { deNamespace, handleErrors } from '@/util/common';
 
 import LzPlot from '@/components/LzPlot.vue';
 import SearchBox from '@/components/SearchBox.vue';
@@ -84,7 +84,7 @@ export default {
     },
     table_sort() {
       // Update how tabulator is drawn, whenever y_field changes
-      return [{ column: `phewas:${this.y_field}`, dir: 'desc' }];
+      return [{ column: this.y_field, dir: 'desc' }];
     },
     query_params() {
       // Re-calculate the URL query string whenever dependent information changes.
@@ -186,7 +186,12 @@ export default {
           'phewas:log_pvalue', 'phewas:gene_id', 'phewas:tissue', 'phewas:system',
           'phewas:symbol', 'phewas:beta', 'phewas:stderr_beta', 'phewas:pip',
         ],
-        (data) => { this.table_data = data; },
+        (data) => {
+          // Data sent from locuszoom contains a prefix (phewas:). We'll remove that prefix before
+          // using it in tabulator, so that tabulator layouts can be written that also work with
+          // data directly from the API (where there is no prefix)
+          this.table_data = data.map((item) => deNamespace(item));
+        },
       );
     },
     goto(refName) {

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -352,13 +352,13 @@ export default {
             <label>
               <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="5"> Top 5 <span id="labels-radio-5" class="fa fa-info-circle"></span></span>
               <b-popover target="labels-radio-5">
-                If viewing P-values, Add labels to the 5 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
+                If viewing P-values, add labels to the 5 most significant eQTLs by P-value <b>if they are more significant than 10<sup>-10</sup></b>.<br><br>If viewing Effect Sizes, choose the eQTLs with the 5 largest absolute effect sizes and only label those with P-values more significant than 10<sup>-20</sup>.
               </b-popover>
             </label>
             <label>
               <span class=nobreak><input type="radio" name="label-options" v-model="n_labels" :value="20"> Top 20 <span id="labels-radio-20" class="fa fa-info-circle"></span></span>
               <b-popover target="labels-radio-20">
-                If viewing P-values, add labels to the 20 eQTLs with the most significant P-values <b>if they are more significant than 10<sup>-10</sup></b>. If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-value more significant than 10<sup>-20</sup>.
+                If viewing P-values, add labels to the 20 most significant eQTLs by P-value <b>if they are more significant than 10<sup>-10</sup></b>.<br><br>If viewing Effect Sizes, choose the eQTLs with the 20 largest absolute effect sizes and only label those with P-values more significant than 10<sup>-20</sup>.
               </b-popover>
             </label>
           </b-dropdown-text>


### PR DESCRIPTION
## Ticket
N/A

## Purpose
- Added a table in region view
- Added the PIP cluster column to the table in both single-variant and region views
- Changed hover tooltips in dropdown menu buttons to popovers
- Made some changes to wording in some popover text
- Updated region view UCSC link to highlight the region being viewed
- Added a button on the top of region view to go to the table
- Added css to prevent line breaks in dropdown menu items
- Updates from #55 have been merged to this branch, because the PIP cluster updates require the display fix for PIP values from there (as a consequence, #55 has been closed)

## How to test this
- Check both single-variant and region views to make sure table is rendering correctly
- Click buttons at the top navbar to make sure they bring you to the correct places
- Check dropdown menus to make sure there are no errant line breaks in button descriptions

## Deployment / configuration notes
(none)
